### PR TITLE
fix: Resolve loading issue and repair narrative flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,39 +477,27 @@
     <p>Arjun bowed, a sign of respect from one warrior to another. Anirudh felt a quiet confidence. He was no longer trying to be someone else. He was on his own path.</p>
 </div>
 <div id="page-90" class="page-content-container">
-    <p>A messenger bird with a scroll tied to its leg flew into the dojo. Anirudh opened it. It was an invitation to the War Council of Realms, the same council where his father had been betrayed. This was a dangerous invitation, and a direct link to his past.</p>
+    <h2>Scene 9: The Invitation</h2>
+    <p>In the quiet of the dojo, as Anirudh and Arjun shared a moment of mutual respect, a messenger bird with shimmering feathers flew through the open window. It carried a scroll sealed with the crest of the War Council of Realms.</p>
+    <p>Anirudh's heart pounded as he opened it. It was a formal invitation to the grand council. The same council where his father had been betrayed.</p>
 </div>
 <div id="page-91" class="page-content-container">
-    <p>Arjun bowed. Anirudh felt a great change. The path was now his own to walk.</p>
+    <p>He looked at Arjun, his eyes full of questions. "This is a trap," Anirudh said, his voice low.</p>
+    <p>"Perhaps," Arjun replied, his face calm. "Or it is an opportunity. The truth you seek about your father may be there. But the council is a nest of vipers. Your strength will be tested in ways you cannot imagine."</p>
 </div>
 <div id="page-92" class="page-content-container">
-    <p>Arjun smiled, a rare sight. "In accepting yourself, you have indeed surpassed," he said. "The greatest mastery is not in techniques, but in understanding your own spirit."</p>
+    <p>Anirudh thought of his journey. The trials, the defeat, the battle for his village. He was no longer the angry orphan seeking revenge. He was a warrior who had found his own strength, his own purpose. He would not be defined by his father's shadow or his enemies' plans.</p>
+    <p>A fire lit in his eyes, not of rage, but of pure resolve. "Then I will go," he said. "I will face them, not as the son of a fallen king, but as myself. I will learn the truth."</p>
 </div>
 <div id="page-93" class="page-content-container">
-    <p>Anirudh stared at the incomplete scroll. "Am I just my father's shadow?" he whispered. The question echoed in the quiet healing chamber.</p>
+    <p>Arjun nodded, a faint, proud smile on his lips. "Then your final trial begins now. You must prepare for a different kind of war. A war of words, of alliances, and of hidden daggers. Go, Anirudh. Your journey awaits."</p>
 </div>
 <div id="page-94" class="page-content-container">
-    <p>Anirudh touched the Whispering Scrolls and his mind was flooded with images of ancient warriors. The knowledge of their fighting styles became a part of him, an instinct he could now use.</p>
+    <h2>Act 3: The Council of Shadows</h2>
+    <p>The journey to the council was long. Anirudh traveled through bustling cities and quiet villages, seeing the world beyond his small town and the secluded temple. He saw the effects of the rising storm Arjun had spoken of – fear, uncertainty, and the growing power of dark forces.</p>
 </div>
 <div id="page-95" class="page-content-container">
-    <p>Anirudh held the invitation to the War Council. His heart pounded. Was it a trap? Or was it his chance to finally learn the truth about his father's death? He knew he had to go.</p>
-</div>
-<div id="page-96" class="page-content-container">
-    <p>Anirudh looked at the invitation. "This is where my father was betrayed," he said to Arjun.</p>
-    <p>"Yes," Arjun said. "A dangerous invitation."</p>
-    <p>A fire lit in Anirudh's eyes. "Then I will go. To uncover the truth."</p>
-</div>
-<div id="page-97" class="page-content-container">
-    <p>[Content for page 97 would continue the story]</p>
-</div>
-<div id="page-98" class="page-content-container">
-    <p>Rudrak, the Thunder Heir, was a true force of nature. His every strike shook the ground. Anirudh, even with his new skills, was being pushed back by the raw power.</p>
-</div>
-<div id="page-99" class="page-content-container">
-    <p>In the healing chamber, Anirudh reflected on his defeat. He realized that the tournament was not the true test. The real test was protecting his village. He no longer needed to win for glory. He returned to the mountains, seeking not new techniques, but a deeper understanding of himself.</p>
-</div>
-<div id="page-100" class="page-content-container">
-    <p>Anirudh moved through the forest, seeking a new kind of challenge. He felt a powerful presence nearby, a guardian of the forest. He remembered the lessons from the scrolls and the animals he had faced. He was ready to weave them all together into his own style.</p>
+    <p>Meanwhile, Elara, Kaelen, and the scholar Elias were on their own journey. Following the clues from Elias's research, they traveled towards the last known location of the Alchemist King's hidden workshop, hoping to find a way to track the child of the prophecy – Anirudh.</p>
 </div>
 <div id="page-101" class="page-content-container">
     <p>In the healing chamber, the pain of his defeat was strong. He felt like all his training had been for nothing. The pressure to live up to his father's legend felt heavier than ever.</p>

--- a/style.css
+++ b/style.css
@@ -11,12 +11,6 @@ body {
     display: flex;
     flex-direction: column; /* Arrange content in a column */
     align-items: center; /* Center content horizontally */
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-}
-
-body.fade-in {
-    opacity: 1;
 }
 
 header {


### PR DESCRIPTION
- I fixed a CSS bug where `opacity: 0` on the body was making the page invisible after the pagination javascript was removed.
- I rewrote and consolidated the narrative for pages 90-100 to fix a jumbled and repetitive story sequence.
- The new sequence provides a clear, linear progression for Anirudh's decision to attend the War Council and sets up the next act.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Major narrative overhaul introducing titled acts/scenes, multi-POV storytelling, and a parallel quest arc with new protagonists and artifacts.
  - Expanded world-building with new sections (e.g., Whispering Scrolls, Animal Trials Begin, Tournament of Rising Suns) and evolving myth-arc themes.
  - Reframed mentorship culminating in an equal-relationship dynamic and a self-fashioned combat philosophy.

- Style
  - Removed page-load fade-in animation; pages now display immediately without opacity transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->