### PR TITLE
feat: complete full 7-act story

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,213 +237,536 @@
 <div id="page-33" class="page-content-container">
     <p>His fingers traced the spines of the ancient books until he found it: a heavy, leather-bound tome with a symbol on its cover that matched the one on his pendant. With trembling hands, he opened it. The book spoke of the Alchemist King, of a powerful lineage, and of monstrous creatures called Wildblood Beasts that were drawn to the king's power. A chill went down his spine. The pendant wasn't just a memento. It was a key. And it made him a target.</p>
 </div>
+<!-- ACT 2: THE RIVALRY -->
 <div id="page-34" class="page-content-container">
-    <h2>Meanwhile, Across the Continent...</h2>
-    <p>The story shifts to a different part of the world, to a trio of adventurers exploring ancient ruins.</p>
-    <p>Elara, a woman with eyes that seemed to see the hidden energy in the world, ran her hand over a set of strange carvings on a crumbling wall. She was a mage, her power tied to the ancient flows of magic in the earth. Beside her stood Kaelen, a stoic warrior in scarred leather armor, his hand resting on the hilt of a massive greatsword. He was her sworn protector, his loyalty as unshakeable as a mountain.</p>
-    <p>"These symbols are unlike any I've seen," Elara murmured, a frown on her face. "They feel... wrong."</p>
+    <h1>Act 2: The Rivalry</h1>
+    <h2>Chapter 1: A New Lead</h2>
+    <p>The words in the ancient tome echoed in Anirudh's mind: "Wildblood Beasts, drawn to the king's power." The pendant around his neck suddenly felt heavier, a beacon in the darkness. He knew he couldn't stay at Kanjiram. The academy was a place of rigid rules and secrets, and he needed answers, not just training. The book mentioned a rival institution, the Vidyut Academy, known for its expertise in ancient lore and magical artifacts. It was a long shot, but it was the only lead he had.</p>
+</div>
+<div id="page-35" class="page-content-container">
+    <h2>Chapter 2: The Journey</h2>
+    <p>Leaving Kanjiram was surprisingly easy. Anirudh was an outcast, a ghost in the hallowed halls. He packed his few belongings, his battered staff, and the heavy book, and slipped out under the cover of darkness. The journey to Vidyut was long and arduous, a test of the survival skills he had honed his entire life. He traveled through dense forests and across treacherous mountains, the pendant a constant, warm presence against his skin.</p>
+</div>
+<div id="page-36" class="page-content-container">
+    <h2>Chapter 3: The Gates of Vidyut</h2>
+    <p>The Vidyut Academy was nothing like Kanjiram. Where Kanjiram was stone and discipline, Vidyut was a vibrant, chaotic hub of magical energy. The air crackled with power, and the students were a diverse mix of scholars, inventors, and warriors. The academy was built around a massive, crystalline structure that pulsed with a soft, blue light. Anirudh, clad in his worn traveler's clothes, felt even more out of place than he had at Kanjiram.</p>
+    <img src="https://via.placeholder.com/600x400?text=Vidyut+Academy" alt="Vidyut Academy">
+</div>
+<div id="page-37" class="page-content-container">
+    <h2>Chapter 4: A Hostile Welcome</h2>
+    <p>Anirudh's arrival did not go unnoticed. A group of Vidyut students, led by a tall, arrogant youth with lightning-fast reflexes, blocked his path. "Another stray from Kanjiram?" the leader sneered. "Lost your way, have you? This is a place of knowledge, not brute force."</p>
 </div>
 <div id="page-38" class="page-content-container">
-    <p>As they ventured deeper, the ground began to glow with a faint, sickly crimson light. The air grew heavy, and a low, chanting sound seemed to rise from the stones themselves. "This is dark magic," Kaelen growled, drawing his sword. "The kind that taints the very soul of a place."</p>
-    <p>They entered a clearing where a group of cloaked figures were performing a ritual, their voices rising in a terrifying chorus. In the center of their circle, a shadowy creature was beginning to form, a being of pure malice and hunger.</p>
+    <h2>Chapter 5: The First Clash</h2>
+    <p>The leader introduced himself as Arjun. He was Vidyut's top student, a master of elemental magic. He saw Anirudh's staff and the raw power in his stance and dismissed him as an uncultured brawler. "You want to enter our halls?" Arjun challenged, his hands crackling with electricity. "You'll have to get through me first."</p>
+</div>
+<div id="page-39" class="page-content-container">
+    <h2>Chapter 6: A Different Kind of Power</h2>
+    <p>Anirudh didn't want to fight, but he wouldn't back down. The clash was brief but intense. Arjun's magic was fast and flashy, a storm of lightning and wind. Anirudh's style was grounded and powerful, each block and parry a testament to his unyielding will. He didn't win, but he held his ground, much to Arjun's surprise and fury.</p>
+</div>
+<div id="page-40" class="page-content-container">
+    <h2>Chapter 7: An Unexpected Ally</h2>
+    <p>A Vidyut instructor, a wise old woman named Master Leela, intervened. She saw something in Anirudh's eyes, a fire that reminded her of the ancient kings. She granted him temporary access to the academy's library, much to Arjun's disgust. "There is more to power than flashy tricks, Arjun," she said, her eyes twinkling. "You would do well to remember that."</p>
+</div>
+<div id="page-41" class="page-content-container">
+    <h2>Chapter 8: The Library of Whispers</h2>
+    <p>Vidyut's library was even larger than Kanjiram's, a labyrinth of towering shelves filled with scrolls and tomes on every imaginable subject. Anirudh spent days poring over ancient texts, searching for any mention of the Alchemist King or the Crimson Pendant. He found whispers, hints of a forgotten history, but nothing concrete.</p>
+</div>
+<div id="page-42" class="page-content-container">
+    <h2>Chapter 9: The Tournament Announcement</h2>
+    <p>The academy was buzzing with excitement. The annual Inter-Academy Tournament was announced, a competition of skill and power between Kanjiram and Vidyut. The grand prize was a rare and powerful artifact from the Vidyut vaults. Anirudh saw it as an opportunity. If he could win, he might gain access to the information he so desperately needed.</p>
+</div>
+<div id="page-43" class="page-content-container">
+    <h2>Chapter 10: A Rival's Scorn</h2>
+    <p>Arjun, of course, was Vidyut's chosen champion. He saw Anirudh's interest in the tournament as an insult. "You think you can compete with me?" he scoffed. "You're a relic, an echo of a forgotten age. This is an era of magic, not brute strength." The rivalry between them intensified, a clash of philosophies and power.</p>
+</div>
+<div id="page-44" class="page-content-container">
+    <h2>Chapter 11: Training Montage</h2>
+    <p>Anirudh began to train with a new ferocity. He knew he was at a disadvantage. He had no formal training in magic. But he had his staff, his will, and the raw, untamed power that flowed from the pendant. He pushed himself to the brink, his body aching, his spirit burning.</p>
+</div>
+<div id="page-45" class="page-content-container">
+    <h2>Chapter 12: A Glimmer of Respect</h2>
+    <p>Arjun, despite his arrogance, couldn't help but notice Anirudh's dedication. He saw the orphan training day and night, his determination unwavering. He wouldn't admit it, but a small part of him was impressed. He started to see Anirudh not as a brawler, but as a warrior.</p>
+</div>
+<div id="page-46" class="page-content-container">
+    <h2>Chapter 13: The First Trial</h2>
+    <p>To qualify for the tournament, Anirudh had to pass a series of trials. The first was a test of intellect, a complex magical puzzle. Anirudh, using the knowledge he had gleaned from the library, solved it in a way no one expected, using logic and observation instead of raw magical power.</p>
 </div>
 <div id="page-47" class="page-content-container">
-    <p>Elara and Kaelen fought bravely, but they were outnumbered. The shadowy creature was immune to Kaelen's blade, and Elara's magic was being suppressed by the dark ritual. They were captured and thrown into a damp, lightless prison cell, the scent of blood and old magic thick in the air.</p>
+    <h2>Chapter 14: The Second Trial</h2>
+    <p>The second trial was a test of stealth. Anirudh had to navigate a booby-trapped maze without being detected. His years of living on the streets, of being unseen and unheard, served him well. He moved through the maze like a phantom, his senses honed to a razor's edge.</p>
 </div>
 <div id="page-48" class="page-content-container">
-    <p>In the cell next to them, they were surprised to find another prisoner. He introduced himself as Elias, a scholar with a wiry frame, a sharp, intelligent face, and spectacles perched on his nose. He had been captured weeks ago while studying the ruins.</p>
-    <p>"They are trying to summon something," Elias explained in a hushed voice, his eyes wide with fear and academic curiosity. "Something connected to the old kings. They are searching for an heir... someone with the blood of the Alchemist King."</p>
-    <p>Elara and Kaelen exchanged a look. The world was larger and more dangerous than they had imagined, and it seemed all paths were leading to a single, unknown child.</p>
+    <h2>Chapter 15: The Third Trial</h2>
+    <p>The final trial was a duel. Anirudh was pitted against one of Vidyut's top magical duelists. The fight was intense, a whirlwind of fire and steel. Anirudh, using his staff and his wits, managed to win, earning a spot in the tournament. He was no longer just the orphan from Kanjiram. He was a contender.</p>
 </div>
 <div id="page-49" class="page-content-container">
-    <p>A storm was gathering. Elias stood at the edge of a deep ravine. The journal he carried, his only link to his past, told him the next clue was on the other side. Though it was dangerous, he knew he had to cross it. He started to climb down into the darkness.</p>
+    <h2>Chapter 16: A New Conspiracy</h2>
+    <p>During his research, Anirudh stumbled upon a dark secret. He found evidence of a hidden faction within Vidyut, a group obsessed with forbidden magic and the power of the Wildblood Beasts. He realized the tournament might be more than just a competition. It could be a trap.</p>
 </div>
 <div id="page-50" class="page-content-container">
-    <p>Elara and Kaelen found a small, carved wooden box on a pedestal. It hummed with ancient magic. As they got closer, the ground trembled, and a tall, shadowy figure appeared. "You intrude where you do not belong," a deep voice said. "The secrets of this place are not for mortals."</p>
+    <h2>Chapter 17: An Unlikely Alliance</h2>
+    <p>Anirudh knew he couldn't face this threat alone. He needed help. He swallowed his pride and approached Arjun, showing him the evidence he had found. Arjun was skeptical at first, but the proof was undeniable. A dark shadow was looming over their world, and they were the only ones who saw it.</p>
 </div>
 <div id="page-51" class="page-content-container">
-    <p>Elara woke up in a damp prison cell. She didn't know how she got there. She heard a groan from the next cell and was relieved to find her friend Kael was alive. But they were trapped, and they didn't know where their other friends were, or what their captors wanted.</p>
+    <h2>Chapter 18: The Scroll of Shadows</h2>
+    <p>The evidence pointed to a legendary artifact, the Scroll of Shadows, which was said to contain the secrets of controlling the Wildblood Beasts. It was hidden somewhere within the academy, in a place known as the Sunken Library. They knew they had to find it before the conspirators did.</p>
 </div>
 <div id="page-52" class="page-content-container">
-    <p>Elara and Kael were climbing a dangerous mountain. The path was narrow, and a single misstep could mean death. The ancient symbols carved into the rock around them seemed to glow. They were close to the summit and whatever secret it held.</p>
+    <h2>Chapter 19: The Sunken Library</h2>
+    <p>Getting to the Sunken Library would be a perilous journey. It was a place of myth and legend, guarded by ancient traps and magical creatures. But they had no choice. The fate of both academies, and perhaps the world, depended on it. Anirudh and Arjun, the rivals, were now reluctant allies.</p>
 </div>
 <div id="page-53" class="page-content-container">
-    <p>Elara and Caelan entered a large cavern. In the center was a large, glowing crystal. It was beautiful and terrifying. A cloaked figure stood before the crystal, their back to them. A feeling of dread washed over Elara. This was the source of the power she had been feeling.</p>
+    <h2>Chapter 20: The Descent</h2>
+    <p>Under the cover of a moonless night, Anirudh and Arjun made their way to the hidden entrance of the Sunken Library. The air grew cold and damp as they descended into the darkness, the weight of their mission heavy on their shoulders. The rivalry was forgotten, replaced by a shared sense of purpose and a growing dread of what they might find below.</p>
 </div>
+<!-- ACT 3: THE SCROLL HUNT -->
 <div id="page-54" class="page-content-container">
-    <p>A swirling vortex of shadows appeared in the clearing. It was a hungry, empty void. Whispers came from it, promising power and secrets if Elara would step inside. The air grew cold and the ground shook. Elara closed her eyes, trying to block out the terrifying sight and the tempting voices.</p>
+    <h1>Act 3: The Scroll Hunt</h1>
+    <h2>Chapter 21: The Guardian</h2>
+    <p>The entrance to the Sunken Library was guarded by a massive stone golem, its eyes glowing with a malevolent red light. It was an ancient guardian, programmed to destroy any intruders. "So much for a quiet entry," Arjun muttered, his hands already crackling with lightning.</p>
 </div>
 <div id="page-55" class="page-content-container">
-    <p>The whispers in Elara's mind grew stronger. The pendant around her neck felt like a shield, pushing back against the strange thoughts. The cave walls began to glow. Was she alone, or was something else in the cave with her, drawn by her pendant's power?</p>
+    <h2>Chapter 22: A Test of Teamwork</h2>
+    <p>The fight was a brutal test of their newfound alliance. Arjun's magic was powerful but ineffective against the golem's stone hide. Anirudh's staff, however, could find the cracks in its armor. They had to work together, Arjun distracting the golem while Anirudh targeted its weak points. It was a clumsy, uncoordinated dance, but it worked.</p>
 </div>
 <div id="page-56" class="page-content-container">
-    <p>In an arena, Elara faced her next opponent, a huge and brutal fighter known as the 'Mountain of Might'. She knew she could not beat him with pure strength. She had to be smart and quick. The fight began, a dance of brute force against nimble evasion.</p>
+    <h2>Chapter 23: The Library's Depths</h2>
+    <p>With the golem defeated, they entered the library proper. It was a breathtaking sight, a massive cavern filled with towering shelves of water-logged books and glowing crystals. The air was thick with the scent of wet paper and ancient magic. "This place is a treasure trove," Arjun whispered in awe.</p>
 </div>
 <div id="page-57" class="page-content-container">
-    <p>Elara and Kaelen found a chamber with a massive, glowing stone in the center, called the Heartstone. The runes on it glowed intensely. As Elara reached for it, a voice spoke in her mind. *You have come. The path has led you here.*</p>
+    <h2>Chapter 24: The First Clue</h2>
+    <p>They began their search, a daunting task in the vast library. Anirudh, using the symbol on his pendant as a guide, found a hidden inscription on one of the shelves. It was a riddle, the first clue in a long and dangerous scavenger hunt for the Scroll of Shadows.</p>
 </div>
 <div id="page-58" class="page-content-container">
-    <p>The whispers grew louder, speaking of old betrayals and a hidden destiny. Elara pressed on through the twisted forest. She felt like she was being watched from the shadows. Was it real, or was her tired mind playing tricks on her?</p>
+    <h2>Chapter 25: A Rival's Intellect</h2>
+    <p>Arjun, with his vast knowledge of magical lore, solved the riddle. It pointed them to a section of the library that dealt with celestial alignments. "The scroll is hidden in a room that is only revealed when the twin moons are in perfect alignment," he explained. They had to hurry. The alignment was only a few hours away.</p>
 </div>
 <div id="page-59" class="page-content-container">
-    <p>A monster attacked, and Kaelen created a shimmering barrier to protect them, but it was cracking. Elara realized the ancient stones around them could disrupt the creature's power. "The magic is still here!" she yelled. "We have to amplify it!" They worked together in a desperate attempt to channel the stones' energy and stop the monster.</p>
+    <h2>Chapter 26: The Water Trap</h2>
+    <p>Their path was blocked by a massive chamber that was rapidly filling with water. There was no visible exit. "A classic pressure plate puzzle," Arjun said, but there was no time to think. The water was rising fast. Anirudh, using his strength, held a collapsing archway open while Arjun frantically searched for the release mechanism.</p>
 </div>
 <div id="page-60" class="page-content-container">
-    <p>The magical stone felt alive in Elara's hands. It began to show a vision of an ancient ritual. The vision expanded, filling the cavern around them. The air grew cold, and a low growl echoed from the shadows. A pair of evil green eyes appeared. The magic wasn't just showing them the past; it had brought something with it.</p>
+    <h2>Chapter 27: A Moment of Trust</h2>
+    <p>Arjun found the mechanism, a series of runes that had to be activated in a specific order. But he couldn't reach it. He had to trust Anirudh to hold the archway long enough. For the first time, they were completely dependent on each other. Anirudh's arms screamed in protest, but he held on, his will a fortress of stone.</p>
 </div>
-<div id="page-60a" class="page-content-container">
-    <p>The shadow creature attacked. Kaelen's sword passed right through it. "It's not solid!" he yelled. "We can't fight it head-on!"</p>
-    <p>Elara saw that the stone was the creature's anchor to their world. "I have to break the connection!" she cried. She focused her own magic on the stone, trying to calm the chaotic energy. The creature shrieked as its body flickered.</p>
+<div id="page-61" class="page-content-container">
+    <h2>Chapter 28: The Chamber of Echoes</h2>
+    <p>They escaped the water trap, only to find themselves in a chamber that echoed with whispers of the past. They saw visions of the Alchemist King, of his great power, and of the terrible betrayal that led to his downfall. Anirudh saw a vision of his mother, her face clear for the first time, and his heart ached with a profound sense of loss.</p>
 </div>
-<div id="page-60b" class="page-content-container">
-    <p>The creature dissolved into smoke as Elara poured her will into the stone. The creature was gone, but the stone was now cold and cracked. Kaelen and Elias rushed to Elara's side. She was pale and leaned against the stone for support.</p>
-    <p>"Are you alright?" Kaelen asked.</p>
-    <p>Elara nodded weakly. "The stone is dormant. But before it faded, I felt a message." She looked at them with urgency. "It spoke of a 'Child of the Crimson Pendant,' and a 'rising storm.' It said the child is the key."</p>
-    <p>Kaelen looked confused, but Elias's eyes widened in recognition. "The Crimson Pendant..." he breathed. "It's not a legend. My research shows it was a real artifact, belonging to the Alchemist King. If there is a child with that pendant, they would be the king's heir."</p>
-    <p>"Then it's real," Elara said, her voice gaining strength. "And we have to find this child. The vision made it clear: they are in danger, and they are at the center of this."</p>
+<div id="page-62" class="page-content-container">
+    <h2>Chapter 29: The Weight of Legacy</h2>
+    <p>The visions shook them both. Arjun saw the destructive potential of unchecked power, and Anirudh felt the immense weight of his legacy. He was the heir to a power that could save the world or destroy it. The pendant around his neck pulsed with a sorrowful energy.</p>
 </div>
-<div id="act-2-novel-version" class="page-content-container">
-    <h2>Act 2: The Forge of the Spirit</h2>
-
-    <h3>Chapter 1: The Forge of the Spirit</h3>
+<div id="page-63" class="page-content-container">
+    <h2>Chapter 30: The Second Clue</h2>
+    <p>In the Chamber of Echoes, they found the second clue, etched into the base of a statue of the Alchemist King. It was a star chart, pointing them to the final location of the scroll: the Celestial Orrery, a massive, clockwork model of the solar system.</p>
+</div>
+<div id="page-64" class="page-content-container">
+    <h2>Chapter 31: The Celestial Orrery</h2>
+    <p>The Celestial Orrery was a magnificent, awe-inspiring sight. Massive golden spheres representing the planets and moons moved in a slow, silent dance, suspended in the air by a powerful magical field. In the center of the room, on a raised platform, was a single, ornate scroll case.</p>
+</div>
+<div id="page-65" class="page-content-container">
+    <h2>Chapter 32: The Final Guardian</h2>
+    <p>As they approached the scroll, a new guardian emerged from the shadows. It was a creature of pure energy, a being of light and shadow that moved with blinding speed. It was a magical construct, far more powerful than the stone golem. "This one is mine," Arjun said, his eyes blazing with determination.</p>
+</div>
+<div id="page-66" class="page-content-container">
+    <h2>Chapter 33: A Display of Power</h2>
+    <p>Arjun unleashed the full extent of his magical power. It was a dazzling display of elemental fury, a storm of lightning, fire, and ice. But the creature was too fast, too ethereal. It seemed to be everywhere at once. Arjun was powerful, but he was also reckless, and he was quickly exhausting his energy.</p>
+</div>
+<div id="page-67" class="page-content-container">
+    <h2>Chapter 34: A Warrior's Strategy</h2>
+    <p>Anirudh saw that Arjun's frontal assault was failing. He had to think like a warrior, not a mage. He watched the creature's movements, looking for a pattern, a weakness. He saw that it always returned to the center of the room to recharge its energy. That was their only chance.</p>
+</div>
+<div id="page-68" class="page-content-container">
+    <h2>Chapter 35: The Perfect Team</h2>
+    <p>Anirudh explained his plan to Arjun. "I need you to create a diversion, a big one. I'll do the rest." Arjun, exhausted and humbled, agreed. He summoned a massive thunderstorm, a chaotic spectacle of light and sound that drew the creature's attention. While it was distracted, Anirudh used his staff to disrupt the magical field that powered the orrery.</p>
+</div>
+<div id="page-69" class="page-content-container">
+    <h2>Chapter 36: The Scroll is Theirs</h2>
+    <p>With the magical field disrupted, the creature flickered and died. The Celestial Orrery ground to a halt. The room was silent. They had done it. Anirudh walked to the platform and picked up the scroll case. The Scroll of Shadows was theirs.</p>
+</div>
+<div id="page-70" class="page-content-container">
+    <h2>Chapter 37: The Betrayal</h2>
+    <p>As they turned to leave, a new figure appeared in the doorway. It was Master Leela, the wise old instructor who had helped Anirudh. But her eyes were cold, her smile venomous. "Thank you for retrieving the scroll for me, boys," she said, her voice dripping with malice. "I'll take it from here."</p>
+</div>
+<div id="page-71" class="page-content-container">
+    <h2>Chapter 38: The True Enemy</h2>
+    <p>Master Leela was the leader of the hidden faction. She had been manipulating them all along, using the tournament and the scroll hunt as a means to get what she wanted. She was a descendant of the very people who had betrayed the Alchemist King, and she sought to reclaim his power for herself.</p>
+</div>
+<div id="page-72" class="page-content-container">
+    <h2>Chapter 39: A Desperate Escape</h2>
+    <p>Anirudh and Arjun were trapped. Master Leela was too powerful. But Anirudh had one last trick up his sleeve. He slammed his staff on the ground, shattering the control panel for the orrery. The massive celestial spheres began to fall, creating chaos and a diversion. They ran, the sound of the collapsing orrery echoing behind them.</p>
+</div>
+<div id="page-73" class="page-content-container">
+    <h2>Chapter 40: A New Resolve</h2>
+    <p>They escaped the Sunken Library, bruised, battered, and betrayed. They had the scroll, but their enemy was more powerful than they had ever imagined. The tournament was no longer about winning. It was about survival. They had to warn the others, to expose Master Leela's conspiracy before it was too late. Their rivalry was now a bond, forged in the fires of betrayal and a shared purpose.</p>
+</div>
+<!-- ACT 4: THE TOURNAMENT -->
+<div id="page-74" class="page-content-container">
+    <h1>Act 4: The Tournament</h1>
+    <h2>Chapter 41: The Calm Before the Storm</h2>
+    <p>The day of the tournament arrived. The academy was a riot of color and celebration, but for Anirudh and Arjun, it was a day of dread. They knew that Master Leela and her followers would be watching, waiting for an opportunity to strike. They had to be careful, to play their part until they could reveal the truth.</p>
+</div>
+<div id="page-75" class="page-content-container">
+    <h2>Chapter 42: The Opening Ceremony</h2>
+    <p>The tournament began with a grand opening ceremony. Students from Kanjiram and Vidyut marched into the arena, their faces a mixture of pride and nervousness. Anirudh saw Rohan in the Kanjiram delegation, his expression as arrogant as ever. He had no idea of the danger they were all in.</p>
+</div>
+<div id="page-76" class="page-content-container">
+    <h2>Chapter 43: The First Round</h2>
+    <p>The first round of the tournament was a series of one-on-one duels. Anirudh was pitted against a Kanjiram student who specialized in defensive techniques. It was a frustrating fight, but Anirudh's relentless pressure eventually broke through, earning him a hard-fought victory.</p>
+</div>
+<div id="page-77" class="page-content-container">
+    <h2>Chapter 44: A Coded Message</h2>
+    <p>Arjun, meanwhile, faced a Vidyut student who he suspected was one of Leela's followers. During the duel, his opponent subtly used a forbidden magical gesture, a coded message. Arjun won the duel, but he knew he was being watched.</p>
+</div>
+<div id="page-78" class="page-content-container">
+    <h2>Chapter 45: A Secret Meeting</h2>
+    <p>That night, they met in secret to discuss their next move. They had to get the scroll to someone they could trust, someone with the power to stop Leela. They decided to seek out the headmaster of Kanjiram, a man known for his wisdom and integrity.</p>
+</div>
+<div id="page-79" class="page-content-container">
+    <h2>Chapter 46: An Unexpected Encounter</h2>
+    <p>As they made their way to the Kanjiram delegation's quarters, they ran into Rohan. He was suspicious of their late-night wanderings and accused them of cheating. Anirudh, seeing no other choice, told him everything. Rohan was skeptical, but the urgency in Anirudh's voice gave him pause.</p>
+</div>
+<div id="page-80" class="page-content-container">
+    <h2>Chapter 47: A New Ally</h2>
+    <p>Rohan, for all his arrogance, was a man of honor. The idea of a conspiracy within the academies disgusted him. He agreed to help them, to use his influence to get them an audience with the Kanjiram headmaster. The three rivals were now united against a common enemy.</p>
+</div>
+<div id="page-81" class="page-content-container">
+    <h2>Chapter 48: The Headmaster's Council</h2>
+    <p>They met with the headmasters of both academies. At first, the headmasters were disbelieving. Master Leela was a respected member of the Vidyut faculty. But the evidence in the scroll was irrefutable. It contained not only the secrets of the Wildblood Beasts, but also a detailed plan for Leela's coup.</p>
+</div>
+<div id="page-82" class="page-content-container">
+    <h2>Chapter 49: The Trap is Sprung</h2>
+    <p>As they were meeting, Leela made her move. She and her followers stormed the arena, using forbidden magic to subdue the crowd. She had a Wildblood Beast with her, a monstrous creature of shadow and fury, held in check by a powerful spell.</p>
+</div>
+<div id="page-83" class="page-content-container">
+    <h2>Chapter 50: The Final Battle Begins</h2>
+    <p>"The age of the academies is over!" Leela declared, her voice booming across the arena. "A new era of power begins now!" The headmasters, along with Anirudh, Arjun, and Rohan, rushed to confront her. The final battle had begun.</p>
+</div>
+<div id="page-84" class="page-content-container">
+    <h2>Chapter 51: A Three-Pronged Attack</h2>
+    <p>Arjun and Rohan, combining their skills, took on the Wildblood Beast. Arjun's elemental magic and Rohan's disciplined swordsmanship made them a formidable team. They fought with a desperate courage, trying to keep the beast from rampaging through the crowd.</p>
+</div>
+<div id="page-85" class="page-content-container">
+    <h2>Chapter 52: The Power of the Pendant</h2>
+    <p>Anirudh faced Leela. She was far more powerful than he was, her mastery of forbidden magic almost absolute. But Anirudh had something she didn't. As she unleashed a powerful spell, the Crimson Pendant on his chest flared to life, absorbing the dark energy. He felt a surge of power, a connection to the ancient magic of his ancestors.</p>
+</div>
+<div id="page-86" class="page-content-container">
+    <h2>Chapter 53: The King's Blood</h2>
+    <p>Leela was stunned. "The blood of the Alchemist King," she whispered, her eyes wide with a mixture of fear and greed. "It's true. You are his heir." She redoubled her attack, desperate to possess the power that was rightfully hers.</p>
+</div>
+<div id="page-87" class="page-content-container">
+    <h2>Chapter 54: An Unlikely Hero</h2>
+    <p>The tide of the battle turned when Rohan, seeing an opening, threw his sword. It wasn't aimed at the beast, but at the amulet Leela was using to control it. The sword struck true, shattering the amulet. The beast, now free from her control, turned on its former master.</p>
+</div>
+<div id="page-88" class="page-content-container">
+    <h2>Chapter 55: The Beast's Fury</h2>
+    <p>The Wildblood Beast, a creature of pure chaos, attacked Leela with a savage fury. She was powerful, but she could not control the monster she had unleashed. Anirudh, Arjun, and Rohan could only watch as the beast and the sorceress battled, their combined power threatening to tear the arena apart.</p>
+</div>
+<div id="page-89" class="page-content-container">
+    <h2>Chapter 56: A Noble Sacrifice</h2>
+    <p>The beast was about to deliver a final, killing blow when the Kanjiram headmaster stepped in. He used a powerful, forbidden spell to banish the beast, sacrificing his own life force in the process. He collapsed, his body fading into light, a final act of courage that saved them all.</p>
+</div>
+<div id="page-90" class="page-content-container">
+    <h2>Chapter 57: The Aftermath</h2>
+    <p>With the beast gone and her plan in ruins, Leela was captured. Her followers were rounded up. The tournament was over, but the celebration had turned to mourning. The headmaster's sacrifice had saved them, but it had come at a terrible cost.</p>
+</div>
+<div id="page-91" class="page-content-container">
+    <h2>Chapter 58: A New Understanding</h2>
+    <p>In the aftermath, Anirudh, Arjun, and Rohan stood together, no longer rivals, but brothers in arms. They had faced death together and had emerged stronger. They had learned the true meaning of power, honor, and sacrifice. The rivalry between their academies seemed petty and insignificant now.</p>
+</div>
+<div id="page-92" class="page-content-container">
+    <h2>Chapter 59: The Road Ahead</h2>
+    <p>Anirudh finally had some of the answers he was looking for. He knew who he was, and he knew the danger he faced. The pendant was not just a key to his past, but a beacon to his enemies. His journey was far from over. He had to learn to control the power within him, to become the hero his parents had always known he could be.</p>
+</div>
+<div id="page-93" class="page-content-container">
+    <h2>Chapter 60: A Shared Destiny</h2>
+    <p>Arjun and Rohan pledged to help him. They knew that the threat of the Wildblood Beasts and those who would seek to control them was not gone. The world needed heroes, and the three of them, the orphan, the mage, and the warrior, would face the future together. Their journey had just begun, a shared destiny that would shape the fate of their world.</p>
+</div>
+<!-- ACT 5: THE FORGE OF THE SPIRIT -->
+<div id="page-94" class="page-content-container">
+    <h1>Act 5: The Forge of the Spirit</h1>
+    <h2>Chapter 1: The Forge of the Spirit</h2>
     <p>At the great gates of Kanjiram Academy, Rohan stood like a sentinel of disapproval, his arms crossed. "So, it's true," he said, his voice a silken weapon. "You're running away. You face a little hardship, a little real discipline, and you flee to the wilds with this... hedge-wizard."</p>
     <p>Anirudh met his gaze, his own expression a calm lake hiding unfathomable depths. "I'm not running away, Rohan. I'm walking towards something."</p>
     <p>Arjun placed a calming hand on Anirudh's shoulder, his eyes twinkling with ancient amusement. "Every river finds its own path to the sea, young Rohan," he said, his voice like stones smoothed by a current. "Some are wide and straight, a testament to their power. Others must carve their way through mountains, a testament to their will. Do not mistake a difficult path for a wrong one." Rohan scoffed, a sharp, ugly sound, but he stepped aside. His eyes, however, never left Anirudh, and in their depths was a promise of a future reckoning.</p>
     <p>The gates of Kanjiram closed behind them, and the world opened up. For weeks, they traveled, leaving the manicured lands of the academy's domain for the rugged, untamed wilderness. Arjun's lessons were not in lectures, but in the rustle of leaves, the scent of rain, the taste of wild berries. "The world is a book, Anirudh," Arjun said one evening, gesturing to the star-dusted sky. "Kanjiram teaches you to read the footnotes. I will teach you to read the poetry." In the quiet of the wilderness, Anirudh began to unlearn the harsh lessons of his youth—the need to fight for every scrap, to trust no one. He learned to breathe. One night, by a crackling fire, Arjun finally explained his choice. "Rohan is a perfect sword, forged and polished in the finest fires. He will win many battles," he said, his gaze distant. "But you, Anirudh... you are the unrefined mountain ore. Rich with potential, but useless as you are. I do not want to make you a sword. I want to teach you how to become the forge."</p>
-
-    <h3>Chapter 2: The Whispering Leaf</h3>
+</div>
+<div id="page-95" class="page-content-container">
+    <h2>Chapter 2: The Whispering Leaf</h2>
     <p>The true training began in a high mountain pass, where the wind sang a lonely song through the rocks. Arjun's first challenge seemed simple, almost a joke. He picked up a single, dry leaf. "Make it dance," he said.</p>
     <p>For hours, Anirudh failed. He pushed his will at the leaf, channeling his energy, his frustration mounting with every twitch and flutter that wasn't his own. He tried to command it, to force it, to treat it as an opponent to be subdued. The leaf lay stubbornly on the rock.</p>
     <p>"You are still thinking like a student at Kanjiram!" Arjun's voice cut through his concentration. "You see a nail, and you reach for a hammer! This is not a technique to be mastered, Anirudh. It is a relationship to be built. The wind is not your servant. It is your partner. You are afraid to let go, to trust in something other than your own strength."</p>
     <p>Arjun's words struck a chord deep within him. He remembered his mother's plea to *live*, not just survive. He let out a long breath, releasing his frustration, his ambition, his fear. He looked at the leaf, and for the first time, he listened. He felt the currents of the air, the subtle eddies and flows. He didn't command. He invited. He extended his own inner calm, his own spirit, and asked the wind to dance with him. And it did. The leaf rose from the rock, not in a violent gust, but in a gentle, swirling spiral, dancing in the air before him, a silent partner in a moment of pure harmony. He had learned the first note of the world's song.</p>
-
-    <h3>Chapter 3: The Proving Ground</h3>
-    <p>The Tournament of Rising Suns was a grand affair, a gathering of the most promising young warriors from across the realms. Anirudh entered not for glory, but to test the limits of his new understanding. His first opponent was a mountain of a man, a brawler named Korg who fought with two massive, spiked gauntlets. The crowd roared for the spectacle of violence they expected.</p>
-    <p>Anirudh, remembering Arjun's lessons, did not meet force with force. He became the wind. He flowed around Korg's clumsy, powerful strikes, his feet barely seeming to touch the ground. He used the brawler's own momentum against him, a gentle touch here, a subtle shift in balance there. Korg, enraged and confused, found himself fighting a phantom, a ghost that was always just beyond his reach. The fight ended not with a bang, but with a whisper. Korg, lunging in a final, desperate charge, found himself suddenly off-balance, stumbling, and landing face-first in the dust, exhausted and defeated. Anirudh hadn't landed a single direct blow.</p>
-    <p>Meanwhile, Rohan, his rival from the academy, was also making his mark. He defeated his own opponents with a clean, precise, and brutal efficiency that the crowd adored. He was the hammer, and every opponent was a nail. His victories were loud, bloody, and spectacular. He was everything Anirudh was not, and the crowd loved him for it.</p>
-
-    <h3>Chapter 4: The Eye of the Storm</h3>
+</div>
+<div id="page-96" class="page-content-container">
+    <h2>Chapter 3: The River's Wisdom</h2>
+    <p>Their journey took them to the banks of a roaring river, a torrent of white water that carved its way through a deep canyon. "Your next lesson," Arjun said, pointing to a massive boulder in the middle of the current. "That rock is strong. It is unyielding. And every day, the river wears it down. It is a fool's strength. The water, however, is soft. It yields. It flows. And it has carved this entire canyon. That is true power."</p>
+    <p>Arjun tasked Anirudh with crossing the river. Not by swimming against the current, but by understanding it. Anirudh spent a full day just watching, feeling the pull of the water, the way it curled around the rocks, the hidden pathways of lesser resistance. He learned that the river's strength was not uniform. There were places of immense power, and places of surprising calm. He learned to see the river not as an obstacle, but as a map.</p>
+    <p>When he finally entered the water, he did not fight it. He yielded to it, letting it guide him, using its own power to carry him across. He was not a warrior battling a foe; he was a leaf on the current, a part of the river's own dance. He reached the other side, exhausted but exhilarated, the river's wisdom now a part of him.</p>
+</div>
+<div id="page-97" class="page-content-container">
+    <h2>Chapter 4: The Silent Mountain</h2>
+    <p>High in the snow-capped peaks, where the air was thin and the silence was absolute, Arjun gave Anirudh his next task. He was to sit before a sheer rock face and do nothing but observe. For days, Anirudh sat, his frustration growing. He saw nothing but rock. He felt nothing but the biting cold.</p>
+    <p>"You are looking, but you are not seeing," Arjun told him one evening. "You see a dead thing. A wall. But the mountain is alive. It breathes. It has a history. It has a spirit. You must learn to listen to its silence."</p>
+    <p>Anirudh, desperate, let go of his expectations. He stopped trying to *find* something. He simply sat, and he listened. He felt the slow, ancient vibration of the mountain, the deep, rumbling life within the stone. He saw the subtle story of the rock face - the scars of ancient glaciers, the faint lines of water that had flowed for millennia, the tiny, tenacious plants that clung to life in its cracks. He realized that the mountain's strength was not in its hardness, but in its endurance, its quiet, unyielding presence. He had learned to see the life in the lifeless, the story in the silence.</p>
+</div>
+<div id="page-98" class="page-content-container">
+    <h2>Chapter 5: A Fateful Encounter</h2>
+    <p>Their path led them to a small, forgotten village nestled in a valley, a place where the air was thick with a strange, sweet sickness. The people were listless, their eyes dull, a creeping lethargy draining the life from them. In the center of the village, a young woman moved among the sick, her face a mask of determined compassion. Her name was Meera.</p>
+    <p>Anirudh and Arjun watched as she tended to the villagers, her touch gentle, her voice a soothing balm. But her efforts were not enough. The sickness was too strong, a creeping shadow that seemed to emanate from the forest itself. Anirudh, moved by the sight of a small child coughing weakly in her mother's arms, felt the familiar urge to *do* something, to fight this unseen enemy.</p>
+    <p>Arjun, however, placed a hand on his arm. "This is not a battle of swords, Anirudh," he said quietly. "This is a battle of a different kind."</p>
+</div>
+<div id="page-99" class="page-content-container">
+    <h2>Chapter 6: The Moonblood's Light</h2>
+    <p>That night, a child's fever spiked. The village healer was helpless. Meera, her face pale with resolve, knelt by the child's side. She closed her eyes, and a soft, silver light began to emanate from her hands. The light flowed into the child, a gentle, pulsing wave of pure life energy. The child's breathing eased, the fever broke. The sickness, for a moment, had been pushed back.</p>
+    <p>Later, Meera explained. She was a Moonblood Healer, a descendant of a long line of guardians sworn to protect the bloodline of the Alchemist King. The pendant on Anirudh's chest was the sign she had been waiting for her entire life. "The sickness in this village is not natural," she explained, her eyes dark with worry. "It is a symptom of the Void's touch, a creeping corruption that drains the life from the land and its people. My light can hold it back, but it cannot cure it." Her duty was clear. She would join Anirudh and Arjun, to be his anchor, his guide, and his protector. The three of them, the warrior, the master, and the healer, were now bound by a shared destiny.</p>
+</div>
+<div id="page-100" class="page-content-container">
+    <h2>Chapter 7: The Proving Ground</h2>
+    <p>The Tournament of Rising Suns was a grand affair, a gathering of the most promising young warriors from across the realms. Anirudh, now accompanied by Arjun and Meera, entered not for glory, but to test the limits of his new understanding. His first opponent was a mountain of a man, a brawler named Korg who fought with two massive, spiked gauntlets. The crowd roared for the spectacle of violence they expected.</p>
+    <p>Anirudh, remembering the river's wisdom, did not meet force with force. He became the water. He flowed around Korg's clumsy, powerful strikes, his feet barely seeming to touch the ground. He used the brawler's own momentum against him, a gentle touch here, a subtle shift in balance there. Korg, enraged and confused, found himself fighting a phantom, a ghost that was always just beyond his reach. The fight ended not with a bang, but with a whisper. Korg, lunging in a final, desperate charge, found himself suddenly off-balance, stumbling, and landing face-first in the dust, exhausted and defeated. Anirudh hadn't landed a single direct blow.</p>
+</div>
+<div id="page-101" class="page-content-container">
+    <h2>Chapter 8: A Rival's Gaze</h2>
+    <p>From the stands, Rohan watched, his expression a mask of cold disbelief. He had expected Anirudh to be crushed. Instead, he had witnessed... a trick. A dance. A coward's victory. He saw Korg, a warrior of immense and honest power, defeated without a single meaningful blow being struck. It was an insult to the very spirit of combat.</p>
+    <p>"He is a charlatan," Rohan muttered to one of his Kanjiram companions. "He uses cheap tricks and illusions to avoid a true fight. He has no honor." But even as he said the words, a small, unsettling seed of doubt took root in his mind. He had seen the look on Korg's face - not just anger, but confusion, as if he had been fighting the wind itself. Rohan pushed the thought away. He was a warrior of Kanjiram. He believed in discipline, in form, in the overwhelming power of a perfectly executed strike. Anirudh's victory was an anomaly, a fluke. It would not happen again.</p>
+</div>
+<div id="page-102" class="page-content-container">
+    <h2>Chapter 9: The Eye of the Storm</h2>
     <p>Anirudh's next opponent was Vana, a woman whose serene smile was at odds with the palpable aura of power that radiated from her. She was a Sound Bender. The moment the gong sounded, the world tilted on its axis. A low, gut-wrenching hum vibrated in Anirudh's bones, his senses twisting into a knot of confusion. The ground seemed to ripple, the air to thicken. He was fighting blind, deaf, and crippled, lost in a sea of sonic chaos.</p>
     <p>His training at Kanjiram screamed at him to fight back, to push through the noise, to overwhelm it with his own power. But Arjun's voice echoed in his mind: *Find the stillness within.* He stopped fighting. He let the cacophony wash over him, a disorienting, painful wave. And in the heart of the noise, in the deafening silence between the waves of sound, he began to perceive a pattern, a rhythm, a flow. He was no longer fighting the sound; he was listening to its song.</p>
     <p>He began to move with it. He flowed through the gaps in her sonic assault, a ghost in her storm, his movements perfectly in sync with the rhythm of her attack. He was a leaf on her wind. He appeared before her, his hand an inch from her throat, his own form a perfect picture of stillness in the heart of her storm. She had lost. Her eyes widened in shock and disbelief. From the stands, Rohan watched, and for the first time since they had parted ways at the gates of the academy, he felt a flicker of genuine, unsettling unease.</p>
-
-    <h3>Chapter 5: The Unmovable Mountain</h3>
-    <p>Both Anirudh and Rohan reached the quarter-finals. A collision seemed inevitable. But fate, it seemed, had other plans. Anirudh's opponent was Rudrak, the Thunder Heir, a warrior so powerful he was already a legend in his own time. The fight was not a duel; it was a force of nature. Rudrak's power was absolute, a raw, unstoppable storm of lightning and thunder. Anirudh tried every trick, every technique, every piece of wisdom he had gained. He tried to be the wind, but the hurricane was stronger. He tried to be the stillness, but the thunder shattered the silence.</p>
+</div>
+<div id="page-103" class="page-content-container">
+    <h2>Chapter 10: The Weight of Victory</h2>
+    <p>That night, Anirudh did not celebrate his victory. He sat with Meera by a quiet fountain, the sound of the water a soothing balm. "I did not defeat her," he said, his voice thoughtful. "I understood her. Her power was a storm, but every storm has a pattern, a rhythm. I just listened."</p>
+    <p>Meera smiled, her eyes reflecting the moonlight. "You are learning, Anirudh. You are learning that power is not just about the strength to break things. It is also about the wisdom to understand them." Anirudh looked at his hands. They were calloused and strong, the hands of a fighter. But for the first time, he felt a different kind of power in them - not the power to destroy, but the power to connect, to feel, to understand. It was a strange, and strangely comforting, feeling.</p>
+</div>
+<div id="page-104" class="page-content-container">
+    <h2>Chapter 11: The Master's Past</h2>
+    <p>Seeing Anirudh's growing understanding, Arjun decided it was time to share a piece of his own past. "I was not always so wise," he admitted one evening, his voice tinged with a long-buried regret. He told them of his youth, of his time as a prodigy at Vidyut Academy, a master of elemental magic with a reckless, arrogant heart. He spoke of a rival, a brilliant alchemist who saw magic not as a weapon, but as a tool for creation.</p>
+    <p>"I saw his work as weak, as a waste of true power," Arjun confessed. "We dueled. I unleashed a storm, a maelstrom of power I could barely control, intending to humiliate him. But he did not fight back. He used his alchemy to create a shield, not of force, but of harmony, a field that absorbed and dissipated my storm, leaving me exhausted and foolish in a field of blooming flowers." Arjun shook his head at the memory. "He taught me that the greatest power is not in destruction, but in creation. That man... was your father, Anirudh."</p>
+</div>
+<div id="page-105" class="page-content-container">
+    <h2>Chapter 12: The Unmovable Mountain</h2>
+    <p>Both Anirudh and Rohan reached the quarter-finals. But fate, it seemed, had other plans. Anirudh's opponent was Rudrak, the Thunder Heir, a warrior so powerful he was already a legend in his own time. The fight was not a duel; it was a force of nature. Rudrak's power was absolute, a raw, unstoppable storm of lightning and thunder. Anirudh tried every trick, every technique, every piece of wisdom he had gained. He tried to be the wind, but the hurricane was stronger. He tried to be the stillness, but the thunder shattered the silence.</p>
     <p>It was like trying to redirect a tidal wave with a feather. He was utterly, completely, and humiliatingly outmatched. The fight ended with a single, devastating blow that felt like being struck by a bolt of lightning. It threw Anirudh across the arena like a broken doll, his body and his spirit shattered. He had lost. And in that moment of crushing defeat, he felt like he had lost everything.</p>
-
-    <h3>Chapter 6: The Hammer and the Key</h3>
-    <p>Anirudh woke in the healing chamber, his body a symphony of pain, his spirit a hollow echo. Arjun sat beside him, his expression unreadable. "You believe power is the ability to overwhelm," Arjun observed, his voice soft. "You faced a greater hammer, and you were shattered. And so now, you believe you are weak."</p>
-    <p>Anirudh had no answer. He just stared at the ceiling, the memory of his failure a bitter taste in his mouth. "Let me tell you a story of your father," Arjun said. He told Anirudh of a time Raghav had faced a Crimson Earth-shaker, a beast of living stone and molten fury. Raghav did not meet its strength with strength. He had "danced" with it, using his Three Seal Harmony Technique to alter the battlefield, turning the very ground into a flowing river, redirecting the beast's power, soothing its rage, until the great creature, its fury spent, simply collapsed into a deep and peaceful slumber.</p>
+</div>
+<div id="page-106" class="page-content-container">
+    <h2>Chapter 13: The Anatomy of Failure</h2>
+    <p>Anirudh woke in the healing tent, his body a symphony of pain. But the physical agony was nothing compared to the hollow emptiness in his chest. Meera sat beside him, her hands glowing with a soft, silver light as she mended his broken bones. "He was too strong," Anirudh whispered, his voice hoarse. "My new way... it was not enough."</p>
+    <p>"Your 'new way' is not a weapon, Anirudh," Meera said softly, her voice a gentle counterpoint to the storm of his self-doubt. "It is a path. And this... this is part of the journey. You cannot understand light without knowing darkness. You cannot know strength without feeling weakness. This pain is not your enemy. It is a teacher." Her words, and the quiet, steady warmth of her healing light, did not erase his failure, but they gave it context. It was not an end. It was a lesson.</p>
+</div>
+<div id="page-107" class="page-content-container">
+    <h2>Chapter 14: The Hammer and the Key</h2>
+    <p>Arjun found him later, staring out at the setting suns, his expression a mask of despair. "You believe power is the ability to overwhelm," Arjun observed, his voice soft. "You faced a greater hammer, and you were shattered. And so now, you believe you are weak."</p>
+    <p>Anirudh had no answer. He just stared at the horizon, the memory of his failure a bitter taste in his mouth. "Let me tell you a story of your father," Arjun said. He told Anirudh of a time Raghav had faced a Crimson Earth-shaker, a beast of living stone and molten fury. Raghav did not meet its strength with strength. He had "danced" with it, using his Three Seal Harmony Technique to alter the battlefield, turning the very ground into a flowing river, redirecting the beast's power, soothing its rage, until the great creature, its fury spent, simply collapsed into a deep and peaceful slumber.</p>
     <p>"Rudrak is the greatest hammer in a generation," Arjun concluded, his eyes locking with Anirudh's. "You tried to meet him as a smaller hammer. You were brave, and you were foolish. The lesson, Anirudh, is not 'how do I become a stronger hammer?'. The lesson is... 'how do I become a key?' A key does not need to be strong. It just needs to be the right shape."</p>
-
-    <h3>Chapter 7: The Orphan's Return</h3>
-    <p>The lesson was still a fresh, painful wound in his mind when news came, carried on the wings of a panicked messenger bird. His old village was under attack by Void-touched beasts. He returned to a place of ghosts and nightmares, but when he saw Old Lady Elina, the one person who had ever shown him a sliver of kindness, cornered by a monstrous, slavering beast, the fight became brutally personal.</p>
-    <p>Pushed to his limits, his body still aching from his defeat, he knew he could not win with force. He had to be the key. He let go of his anger, his fear, his doubt. He let go of the desire to win, and embraced a new, more powerful desire: the need to protect. In that moment of selfless clarity, a new power, calm, focused, and potent, surged through him. It was not the rage of the storm, but the certainty of the mountain. It was the speed of the wind, guided by the stillness of the stone. It was the Vayu Vajra, the Wind Thunder Form, born not in quiet meditation, but in a moment of selfless, desperate action.</p>
+</div>
+<div id="page-108" class="page-content-container">
+    <h2>Chapter 15: The First Spark</h2>
+    <p>The journey back to the wilderness was a quiet one. The sting of defeat was a constant companion. Anirudh's training began anew, but this time, it was different. There were no grand challenges, no dramatic lessons. Arjun had him sit by a stream and watch the water flow over the rocks. He had him feel the grain of the wood in his staff. He had him listen to the silence between the notes of a bird's song.</p>
+    <p>"The key is not a thing you make," Arjun explained. "It is a thing you become. It is about understanding the lock. You must learn to see the world not as a collection of objects, but as a web of connections, a flow of energy. You must find the empty spaces, the points of leverage, the hidden pathways." Anirudh began to see the world in a new light, not as a series of obstacles, but as a series of puzzles waiting to be solved.</p>
+</div>
+<div id="page-109" class="page-content-container">
+    <h2>Chapter 16: The Echo of Power</h2>
+    <p>Arjun began to teach Anirudh the basics of the Three Seal Harmony Technique, the style his father had used. It was unlike anything he had ever learned. It was not about generating power, but about guiding it. His first task was to create the simplest seal, the Seal of Stillness. It was a complex pattern of energy that, when formed correctly, would create a small zone of absolute calm.</p>
+    <p>For days, Anirudh failed. The energy would not hold its shape, dissipating like smoke. He was trying to force it, to command it, as he had with the leaf. "You are trying to build a dam," Arjun said. "You must become the riverbank. You do not hold the water back. You guide its flow." Anirudh, remembering the mountain's lesson, let go of his effort. He did not try to create the seal. He invited it to form. And in a moment of quiet clarity, the seal appeared, a faint, glowing pattern in the air before him, a perfect, beautiful, and fragile thing.</p>
+</div>
+<div id="page-110" class="page-content-container">
+    <h2>Chapter 17: The Orphan's Return</h2>
+    <p>The lesson was still a fresh, fragile thing in his mind when news came, carried on the wings of a panicked messenger bird. His old village, the one that had scorned him, was under attack by Void-touched beasts. He, Arjun, and Meera rushed back, arriving to a scene of chaos and terror. He returned to a place of ghosts and nightmares, but when he saw Old Lady Elina, the one person who had ever shown him a sliver of kindness, cornered by a monstrous, slavering beast, the fight became brutally personal.</p>
+</div>
+<div id="page-111" class="page-content-container">
+    <h2>Chapter 18: The Protector's Heart</h2>
+    <p>Pushed to his limits, his body still aching from his defeat at the tournament, Anirudh knew he could not win with force. He had to be the key. As the beast lunged, he did not meet it with a blow. He moved to protect. He threw himself in front of Old Lady Elina, his arms spread wide, his body a shield. He was not trying to win. He was not trying to survive. He was only trying to protect.</p>
+    <p>In that moment of selfless clarity, something inside him unlocked. A new power, calm, focused, and potent, surged through him. It was not the rage of the storm, but the certainty of the mountain. It was the speed of the wind, guided by the stillness of the stone. It was the Vayu Vajra, the Wind Thunder Form, born not in quiet meditation, but in a moment of selfless, desperate action.</p>
     <p>He moved like a storm, but a storm with a purpose. He struck not with the force of a hammer, but with the precision of a key turning a lock. He dismantled the beast, turning its own strength against it, and saved the village. In the eyes of the villagers, he was no longer an orphan. He was a protector. He had found his path.</p>
-
-    <h3>Chapter 7.5: The Weight of a Name</h3>
+</div>
+<div id="page-112" class="page-content-container">
+    <h2>Chapter 19: The Weight of a Name</h2>
     <p>That night, by the fire in the now-safe village square, Arjun found Anirudh staring into the flames, his hands trembling slightly. "You are wondering about the power you called upon," Arjun said, not as a question, but as a statement. Anirudh nodded, unable to speak.</p>
     <p>"The Vayu Vajra is not a technique, boy. It is a manifestation," Arjun explained, his voice low. "It is the spirit's answer to a selfless heart. It is the power of the wind, which flows, and the power of the thunder, which strikes. But it is guided by the stillness of the mountain, by a purpose greater than oneself. You did not call it forth to win a fight. You called it forth to protect. That is the key."</p>
     <p>Arjun grew serious, his gaze intense. "But be warned. A power like that, born of such emotion, is a fire that can consume its wielder. It draws upon your life force, your very essence. If you were to use it from a place of rage, or hatred... it would burn you from the inside out, leaving nothing but an empty, echoing shell. You have been given a great gift, Anirudh. Do not let it become your curse."</p>
-
-    <h3>Epilogue: The Invitation</h3>
-    <p>When he returned to the Whispering Temple, Arjun looked at him with a new light in his eyes. "You have not surpassed my teachings," Anirudh said, a quiet confidence in his voice that was not there before. "I have only just begun to understand them. I have accepted who I am."</p>
+</div>
+<div id="page-113" class="page-content-container">
+    <h2>Chapter 20: The Invitation</h2>
+    <p>When he returned to the Whispering Temple, their temporary home in the wilderness, Arjun looked at him with a new light in his eyes. "You have not surpassed my teachings," Anirudh said, a quiet confidence in his voice that was not there before. "I have only just begun to understand them. I have accepted who I am."</p>
     <p>Arjun bowed, not as a master to a student, but as an equal. "Then your training is complete," he said. In that moment of quiet triumph, a messenger bird arrived, its wings beating urgently against the air. It carried a scroll, sealed with the ominous crest of the War Council of Realms. It was an invitation to the grand council, the same council where his father had been betrayed. The final trial was about to begin.</p>
 </div>
-<div id="act-3-novel-version" class="page-content-container">
-    <h2>Act 3: The Council of Shadows</h2>
-
-    <h3>Chapter 1: The Road of Whispers</h3>
-    <p>The morning after the battle, the elders of the village approached Anirudh. Old Lady Elina, her eyes clear and bright with unshed tears, was at their head. "You saved us," she said, her voice trembling with gratitude. "But this darkness... it is a plague, and it is spreading. You should not go to the council alone." She turned to Meera. "Our Meera has the gift of healing, a gift of the Moon's light. But she also has the gift of sight. She sees the hearts of people, the light and the shadow within. An old duty, long forgotten, falls to her now. She will be your anchor, Anirudh. And your guide."</p>
-    <p>"It is not a simple mending of flesh, Anirudh," she added, her voice low and reverent. "The Moon's light is the light of life itself. A Moonblood Healer does not just close a wound; they share a piece of their own soul, their own vitality, to rekindle the fading spark in another. It is a profound gift, but one that carries a great cost. Remember that, boy. Protect her, as she will undoubtedly protect you."</p>
-    <p>Meera's decision was already made. The pendant on Anirudh's chest was a confirmation of a duty her family had passed down in whispers for generations. "I will go," she said, her voice quiet but firm, her eyes meeting Anirudh's with a depth that spoke of a shared destiny.</p>
-    <p>Their journey was a pilgrimage through a dying land. In the town of Oakhaven, they saw fields left fallow, the farmers too afraid to work them. They stopped to help a family whose cart had broken, and Anirudh saw the gaunt, haunted look in their children's eyes. This was not a war fought on some distant battlefield; it was a sickness in the very heart of the world. In the market town of Silverstream, they saw that fear being weaponized. A charismatic merchant with a silver tongue stood on a cart, his voice a balm and a poison. "Yes, the Shadow Faction is evil!" he cried, his voice ringing through the square. "But why are they so bold? Because the other factions are weak! The Martial Clans hoard their strength! The Alchemy Order hoards its secrets! They leave us defenseless!"</p>
-    <p>Anirudh felt his hands clench, a familiar fire rising in his chest. The man's words were a subtle, twisting poison, turning the people's fear into suspicion, their unity into division. He took a step forward, ready to challenge the man, but Meera's hand on his arm stopped him. "Look at their faces, Anirudh," she whispered, her voice a sad, soft thing. "They are not listening to his words. They are listening to their own fear. This is not a battle you can win with your fists." He looked, and he saw the desperate, hungry look in the eyes of the crowd. They were desperate for someone to blame. He realized, with a sinking heart, that this was a battlefield he did not understand. He could not punch a bad idea. The poison had already taken root.</p>
-
-    <h3>Chapter 2: Echoes in the Dust</h3>
-    <p>Miles away, in a ruined, dust-choked archive, Elara, Kaelen, and Elias waged a different kind of war—a war of whispers and forgotten lore. After days of searching, battling ancient, crumbling guardians, Elias found a hidden scroll, protected by a complex Lore Golem they were forced to painstakingly disable. The scroll was a single, cryptic sentence from the Alchemist King himself: *"The Serpent I trusted wears a crown of knowledge. The key to my legacy lies not in the light, but in the shadow of the mountain, where Vajradan sleeps."*</p>
-    <p>As Elara read the words, a vision flooded her mind, a chaotic, terrifying torrent of images: a flash of a hooded figure with a serpent tattoo coiling around their wrist; a glimpse of a breathtaking city of glass and brass sinking into a bottomless chasm; and a whisper on the wind, a word that chilled her to the bone: "...betrayal...". She stumbled back, her hand flying to her mouth, the implication terrifying. The Serpent was not a myth; it was a person, a person who had been close to the king, a person who wore a "crown of knowledge." Their path was now clear, and impossibly dangerous. They had to find the Sunken City of Vajradan, a place most scholars believed to be a mere legend.</p>
-
-    <h3>Chapter 3: The Den of Vipers</h3>
-    <p>The mountain fortress of the War Council was a tomb of secrets, cold and vast. The council chamber itself was designed to intimidate, a cavern of polished obsidian and faded tapestries depicting ancient, bloody betrayals. As Anirudh and Meera entered, a hush fell over the room. They were met with a hundred stares of suspicion, disdain, and in a few, a flicker of fear. Anirudh saw the factions gathered in tense, whispering clusters: the stoic, honorable warriors of the Martial Clans, their hands never far from their swords; the enigmatic scholars of the Alchemy Order, led by the serenely smiling Lord Varash; and the silent, unnerving delegates of the Shadow Faction, their faces hidden in shadow, their very presence an insult to this supposedly sacred hall.</p>
-    <p>It was then that he saw The Whisperer. They were a grey, cowled figure, moving between the groups like a ghost, their movements silent, their presence almost imperceptible. Anirudh watched as The Whisperer leaned in to speak to the General of the Martial Clans. The General's face, a moment before a mask of stern confidence, paled. He glanced across the room at Lord Varash, a new, ugly suspicion in his eyes. The Whisperer had planted a seed. A moment later, they were speaking to a delegate from the Shadow Faction, and a slow, cruel smile spread across the delegate's hidden face. The Whisperer was not just a delegate; they were the true power in the room, a master puppeteer playing on the strings of fear, greed, and ambition, and the so-called leaders of the free world were dancing to their tune.</p>
-
-    <h3>Chapter 4: The Ghost on the Mountain</h3>
-    <p>"It's a game to them!" Anirudh burst out that night, his voice a raw, angry sound as he paced a secluded, windswept balcony. "A game of words and shadows and whispered lies, while the world burns! They argue about trade routes while villages are put to the torch! This isn't a council; it's a farce!"</p>
-    <p>Arjun found him there, his expression grim, his eyes heavy with a sorrow that seemed to emanate from the very stone of the fortress. "I have seen this game before," he said, his voice quiet. "And I have seen how it ends." And so, he told him. He told him the full, ugly, heartbreaking truth of what had happened in this fortress fifteen years ago. He spoke of Raghav's dream of an alchemical accord, a plan to use his knowledge to end famine, to cure disease, to lift the entire world into a new age of prosperity. He spoke of the whispers of dissent, the accusations of hoarding power, all started by a man who called himself Raghav's friend.</p>
-    <p>"You must understand, Anirudh," Arjun continued, his voice a low growl, "the Void style is not just a set of techniques. It is a philosophy of emptiness. To master it, one must empty themselves of all attachments—of love, of hope, of mercy. It replaces what is human with a cold, hungry nothingness. Kavrik did not just learn a new way to fight; he carved out his own soul."</p>
-    <p><i>Arjun's mind flashed back, an unwanted memory, sharp as glass. He saw Raghav and Kavrik, twenty years younger, sparring in a sun-drenched courtyard. Raghav, brilliant and laughing, disarmed Kavrik with a flick of his wrist. "Your heart is not in it today, my friend," Raghav had said, clapping him on the shoulder. "Your mind is on that pretty scribe from the lower city!" Kavrik, flustered and proud, had just shoved him back, a wide, honest grin on his face. They were brothers, closer than any blood. The memory was a bitter poison.</i></p>
-    <p>"Your father was a brilliant man, Anirudh, but he believed in the best of people, even when they showed him their worst," Arjun said, his voice cracking with the memory. "He stood on this very balcony and tried to reason with them, to show them the beauty of his dream. But his calm, reasoned defense was useless against a tide of fear and greed." Then he spoke of the final, terrible moment. "The vote failed. The accord was rejected. And then came the assassins. Kavrik... your father's most trusted friend... his sworn brother... he was supposed to be guarding his back. But he stepped aside. He created the opening. I saw it, Anirudh. I saw the surprise, the hurt, in your father's eyes. And I was too far away to stop it."</p>
-    <p>Arjun's voice broke, the confession a physical weight that seemed to bow his strong shoulders. "I have lived with that failure, that moment of helplessness, every day for fifteen years. That chance for atonement... is you." The story hung in the cold night air, a terrible, heavy thing. Anirudh looked at his master, at the raw pain in his eyes, and his own rage cooled, hardening into something else, something stronger. He placed a hand on Arjun's shoulder. "You did not fail him," he said, his voice quiet, but filled with a new, unshakeable, and terrifying strength. "His friends failed him. The council failed him. I will not."</p>
+<!-- ACT 6: THE COUNCIL OF SHADOWS -->
+<div id="page-114" class="page-content-container">
+    <h1>Act 6: The Council of Shadows</h1>
+    <h2>Chapter 1: The Road of Whispers</h2>
+    <p>The journey to the War Council was a pilgrimage through a world gasping for breath. Anirudh, Arjun, and Meera traveled roads flanked by fallow fields and silent, watchful forests. The air itself seemed heavy with unspoken fear. In the towns, the smiles were brittle, and the nights were guarded by men with haunted eyes. With every league they traveled, Anirudh felt the purpose in his heart sharpen into a fine, hard point. He was no longer just seeking answers; he was seeking justice.</p>
+    <p>Beside him, Meera was a bastion of calm. Her quiet strength, the observant stillness in her gaze, became his anchor in the growing storm of his own thoughts. She would often point out small details he would have missed in his focused intensity - a rare flower pushing through a crack in a barren rock, the sound of children's laughter from a hidden courtyard. She was teaching him, in her own quiet way, what they were fighting for.</p>
 </div>
-<div class="story-container">
-    <h2>War of Power</h2>
-    <h3>Section 1: Shadows Before the Storm</h3>
-    <p>The journey to the War Council was a pilgrimage through a world gasping for breath. Anirudh and Meera traveled roads flanked by fallow fields and silent, watchful forests. The air itself seemed heavy with unspoken fear. In the towns, the smiles were brittle, and the nights were guarded by men with haunted eyes. With every league they traveled, Anirudh felt the purpose in his heart sharpen into a fine, hard point. Beside him, Meera was a bastion of calm. Her quiet strength, the observant stillness in her gaze, became his anchor in the growing storm of his own thoughts. "She sees the world differently," he mused, watching her trace a pattern on a frosted windowpane. "Not as a battlefield, but as a tapestry. I need that."</p>
-    <p>They finally arrived at the War Council of Realms, a fortress not built, but gouged from the heart of a mountain, a place of cold stone and colder politics. The air within the council chamber was a physical weight, thick with centuries of mistrust. Anirudh saw the factions clinging to their own kind: the proud, unbending warriors of the Martial Clans; the aloof, whispering scholars of the Alchemy Order; and the delegates of the Shadow Faction, whose very presence seemed to drain the light from the room. He was an outsider, a disruption, and he felt the weight of a hundred suspicious eyes on him, judging him, measuring him.</p>
+<div id="page-115" class="page-content-container">
+    <h2>Chapter 2: The Weight of the Invitation</h2>
+    <p>One night, by a meager fire, Anirudh studied the scroll of invitation. The ominous crest of the War Council seemed to mock him. "They invite me to talk," he said, his voice laced with bitterness. "The same council that stood by while my father was murdered."</p>
+    <p>Arjun's expression was grim. "This is not an invitation, Anirudh. It is a summons. They are afraid of you, of the power you represent. They want to measure you, to see if you are a tool they can use, or a threat they must eliminate."</p>
+    <p>Meera placed a hand on Anirudh's arm. "They may be afraid," she said, her voice firm. "But they are also the only hope for a united front against the growing darkness. We cannot fight this war alone. You must go. Not as your father did, with hope in your heart. But as yourself, with wisdom in your eyes." Anirudh looked at the two of them, his master and his friend, and a new resolve settled in his heart. He would face this council, not as a victim, but as a warrior.</p>
+</div>
+<div id="page-116" class="page-content-container">
+    <h2>Chapter 3: The Den of Vipers</h2>
+    <p>They finally arrived at the War Council of Realms, a fortress not built, but gouged from the heart of a mountain, a place of cold stone and colder politics. The air within the council chamber was a physical weight, thick with centuries of mistrust. Anirudh saw the factions clinging to their own kind: the proud, unbending warriors of the Martial Clans; the aloof, whispering scholars of the Alchemy Order; and the delegates of the Shadow Faction, whose very presence seemed to drain the light from the room.</p>
     <p>He watched a figure, known only as The Whisperer, drift between the delegations like a phantom. Their face was lost in the shadow of a deep cowl, but their influence was a palpable poison. A shared laugh would die, a friendly hand would be withdrawn, a seed of doubt would be planted with a single, honeyed word. Anirudh felt a cold dread creep up his spine. This was not a council of allies; it was a den of vipers, charmed into a dance of self-destruction. This was how his father's dream had died. Not with a bang, but with a whisper.</p>
-    <p>That night, as two moons illuminated the jagged peaks outside, Arjun found him on a secluded balcony. The master's voice was low, heavy with the ghosts of the past. "Look at them, Anirudh. The same pride. The same fear. This is the same stage, with the same puppets. Your father, Raghav, stood on this very spot and spoke of unity. He was betrayed not by an army, but by a 'friend' who smiled to his face while sharpening the knife. History is a hungry beast, Anirudh. It loves to repeat itself. Trust no one here. Trust only the fire in your own heart."</p>
-
-    <h3>Section 2: The First Ambush</h3>
-    <p>The attack came without warning on a lonely mountain pass. One moment, the air was still; the next, it was filled with ghosts. The Shadow Assassins didn't move through the world; they slid between its cracks, their blades not just cutting flesh, but tasting life. The very air grew cold and thin, each breath a struggle. Their leader was Kavrik, a man whose face was a ruin of void-scarred flesh, but whose eyes burned with the cold, dead light of a collapsed star. He was a master of a forbidden art, a combat style that was a cancer upon the world.</p>
-    <p>They ignored Anirudh. Their target was Meera. As they closed in, a vortex of shadow forming around her, a brilliant, blinding nova of silver light erupted from her core. The assassins were hurled back, screeching as the pure, living energy seared their void-touched forms. She was a Moonblood Healer, a living font of life, and the Shadow Faction's natural enemy. Anirudh, stunned for a heartbeat, roared with protective fury and met them head-on.</p>
-    <p>He fought with the grace of a storm, but Kavrik was a void. Anirudh's every strike was swallowed by the man's unnatural defense. He felt his own energy, his own life force, being siphoned away, his movements growing sluggish, his spirit heavy. He faced Kavrik and was utterly, crushingly defeated. As he lay broken on the ground, Kavrik loomed over him, the ghost of a smile on his ruined face. "Your father's blood makes you strong," he hissed, his voice the rustle of dry leaves. "But it is a fire I will enjoy extinguishing. Your entire bloodline will burn first."</p>
-
-    <h3>Section 3: Training in the Ruins</h3>
-    <p>Arjun carried the wounded and humiliated Anirudh to the Ruins of Vajradan, a city of shattered towers and sleeping magic, a place where his father had once learned to master the elements. "You fought the void with fire," Arjun said, his voice echoing in the vast, silent halls. "But you cannot burn a vacuum. To defeat the void, you must understand it. And to understand it, you must face the ultimate emptiness: death itself."</p>
-    <p>He led Anirudh to a sealed chamber at the heart of the ruins, a place that hummed with a terrifying, latent power. "This chamber will show you your own end," Arjun explained. "It will strip away everything you are. You must find the spark that remains, or be consumed forever." Inside, Anirudh's world dissolved. He was pulled into a harrowing, vivid vision of his father's last moments. He saw the council chamber, felt the sting of betrayal as Kavrik, his father's sworn brother, stepped aside, allowing the assassins to strike. He heard his father's final, defiant words. He felt his father's life extinguish.</p>
-    <p>Anirudh did not just see it; he lived it. He screamed, not in his mind, but in the chamber, a sound of pure, elemental grief and rage. And from that crucible of loss, a new power was born. He emerged from the chamber not just alive, but reborn in golden fire. The Vayu Vajra Ascendant Form crackled around him, a cloak of lightning and wind, a power so immense it threatened to tear his own body apart even as it obeyed his will. He had touched death, and returned with its power.</p>
-
-    <h3>Section 4: The Siege of Kanjiram Academy</h3>
-    <p>The Shadow Faction, emboldened, threw their full might at Kanjiram Academy, a brazen declaration of war. A tide of corrupted wild beasts, their eyes glowing with malevolent purple light, crashed against the academy walls. The siege was a maelstrom of chaos and terror. But Anirudh, now a warrior transformed, became the eye of the storm. His Ascendant Form was a golden comet on the battlefield, a beacon of impossible hope against the encroaching darkness. He moved with the speed of thought, his every strike a thunderclap, single-handedly turning the tide at the main gate by felling a monstrous Flamehorn Rhino that had shattered the ancient defenses.</p>
-    <p>Meera, her heritage now revealed, became a silver angel on the battlefield. She moved through the wounded, her hands glowing, knitting together flesh and bone, her very presence a shield against the creeping shadows of despair. And Arjun, a whirlwind of steel and fury, was a legend reborn, single-handedly holding the western wall against three of the Shadow Faction's most feared generals. But the enemy had held back their trump card. From the heart of their army, a creature of nightmare emerged: the Obsidian Direwolf, a Beast King of shadow and moonlight, its howl a promise of death. It ignored the chaos, its intelligent, malevolent eyes fixing on the golden comet in the main courtyard. It had found its prey.</p>
-
-    <h3>Section 5: Duel with the Direwolf</h3>
-    <p>The world seemed to hold its breath. The duel was not just a fight; it was a clash of mythic forces. The Direwolf was a living shadow, cloaking itself in darkness to strike from unseen angles, its claws dripping with energy-draining void magic. Anirudh, in his Ascendant Form, was a being of pure, golden light, but he could feel his energy draining, the immense power of the form taking its toll. He was burning out.</p>
-    <p>Pushed to his absolute limit, his mind raced back to the dusty, forgotten tomes in the library, to the theories of his father. He began to weave intricate, glowing alchemical seals into the air with his free hand, a skill inherited, but never mastered. A seal of Binding to counter the beast's phasing. A seal of Purity to negate its regenerative abilities. The duel shifted from a brawl to a deadly, high-speed chess match. The odds were evened, but Anirudh knew it wasn't enough. He was fading.</p>
-    <p>He made a final, desperate gamble. He drew upon the teachings of the incomplete Death-Resurrection Scroll, a forbidden technique that traded life for absolute power. He channeled his own life force, his very essence, into one, final, cataclysmic strike. "VAYU VAJRA!" he roared, his voice the sound of a star being born. He became a golden meteor, striking the Direwolf with the force of a falling mountain. The beast, and the entire courtyard, were consumed by a blinding, silent explosion of golden light.</p>
-    <p>When the light faded, Anirudh lay at the center of a crater, his body still, the golden light of his Ascendant Form extinguished. His heart had stopped. For three long minutes, he was dead. The battle ground to a halt, friend and foe alike staring in stunned silence. And then, Meera reached him. With tears streaming down her face, she poured her own life force, her Moonblood essence, into his still form, a desperate, loving prayer against the encroaching darkness. His heart sputtered, then beat once. Then again. He had won, but at a cost that had nearly shattered them all.</p>
-
-    <h3>Section 6: Secrets Unveiled</h3>
-    <p>In the quiet aftermath, amidst the scent of ozone and healing herbs, Arjun sat by Anirudh's bedside and finally unburdened his soul. He told him everything. That his father, Raghav, was not just a great warrior, but the last Alchemist King, a man who could reshape the very fabric of reality. He explained that Meera's family were not just villagers, but the sworn guardians of the king's bloodline, a duty passed down through generations, which was why she had been sent to find him, to protect him, to be his anchor.</p>
-    <p>And then came the final, devastating blow. Kavrik, the master of the void, the man who had defeated him, the man who had betrayed his father... was once Raghav's most beloved friend, his sworn brother, his most trusted ally. The betrayal was not political; it was personal, a wound that had festered for fifteen years. Anirudh listened, his expression hardening from stone to diamond. The grief, the anger, the loss... it all coalesced into a single point of cold, clear, and absolute resolve. He would not just defeat the Shadow Faction. He would find Kavrik, and he would erase the stain of his betrayal from the world.</p>
-
-    <h3>Section 7: The Gathering Storm</h3>
-    <p>Word of the impossible victory at Kanjiram spread like wildfire, but it did not bring peace. The Whisperer used the brazen attack to whip the other factions into a frenzy of fear and paranoia. Armies, once held in reserve, began to muster. A final, cataclysmic battle was now inevitable, the stage set in the desolate, cursed landscape of the Valley of Blood Moons.</p>
-    <p>Anirudh and his allies began to train with a new, grim intensity. He worked on mastering his costly Ascendant Form, on developing counters to Kavrik's soul-draining void style. In a rare, quiet moment, under the light of the twin moons, he and Meera stood on the academy's highest tower, looking out at the world they were about to fight for. Words were unnecessary. He took her hand, a silent confession of feelings that ran deeper than words, a small, perfect moment of peace in a world teetering on the brink of annihilation.</p>
-    <p>The final scene is a vast, sweeping shot. The armies of the allied factions, a river of steel and hope, march towards the valley. Above them, the sky is a bruised purple, lit by the two ominous, blood-red moons. The final war, for the soul of the world, was about to begin.</p>
 </div>
-<div id="act-4-final-version" class="page-content-container">
-    <h2>Act 4: The Valley of Blood Moons</h2>
-
-    <h3>Chapter 1: The Crimson Fields</h3>
+<div id="page-117" class="page-content-container">
+    <h2>Chapter 4: A Glimpse of the Past</h2>
+    <p>That night, Arjun stood on a secluded balcony, the same one where he had spoken to Anirudh what felt like a lifetime ago. The memories were ghosts, whispering in the wind. He remembered Raghav, standing on this very spot, his face alight with the passion of his dream. He remembered the looks on the faces of the other council members - greed, fear, envy. He remembered the moment of the betrayal, the flash of steel, the look of shocked surprise on his friend's face. The guilt was a cold, heavy stone in his gut. He had failed his friend then. He would not fail his son now.</p>
+</div>
+<div id="page-118" class="page-content-container">
+    <h2>Chapter 5: The First Ambush</h2>
+    <p>The attack came without warning on a lonely mountain pass as they were returning from a scouting mission. One moment, the air was still; the next, it was filled with ghosts. The Shadow Assassins didn't move through the world; they slid between its cracks, their blades not just cutting flesh, but tasting life. The very air grew cold and thin, each breath a struggle.</p>
+</div>
+<div id="page-119" class="page-content-container">
+    <h2>Chapter 6: The Moon's Shield, The Void's Sword</h2>
+    <p>Their leader was Kavrik, a man whose face was a ruin of void-scarred flesh, but whose eyes burned with the cold, dead light of a collapsed star. They ignored Anirudh. Their target was Meera. As they closed in, a vortex of shadow forming around her, a brilliant, blinding nova of silver light erupted from her core. The assassins were hurled back, screeching as the pure, living energy seared their void-touched forms. She was a Moonblood Healer, a living font of life, and the Shadow Faction's natural enemy. Anirudh, stunned for a heartbeat, roared with protective fury and met them head-on.</p>
+</div>
+<div id="page-120" class="page-content-container">
+    <h2>Chapter 7: The Bitter Taste of Defeat</h2>
+    <p>He fought with the grace of a storm, but Kavrik was a void. Anirudh's every strike was swallowed by the man's unnatural defense. He felt his own energy, his own life force, being siphoned away, his movements growing sluggish, his spirit heavy. He faced Kavrik and was utterly, crushingly defeated. As he lay broken on the ground, Kavrik loomed over him, the ghost of a smile on his ruined face. "Your father's blood makes you strong," he hissed, his voice the rustle of dry leaves. "But it is a fire I will enjoy extinguishing. Your entire bloodline will burn first."</p>
+</div>
+<div id="page-121" class="page-content-container">
+    <h2>Chapter 8: The Price of Light</h2>
+    <p>Kavrik and his assassins vanished as quickly as they had appeared, leaving Anirudh broken and Meera exhausted. The burst of light that had saved them had taken a heavy toll on her. She swayed, her face pale, and Arjun caught her before she could fall. Anirudh, his body screaming in protest, dragged himself to her side. He saw the fatigue in her eyes, the way her own light seemed to dim. He had been so focused on his own power, his own legacy, that he had forgotten that she was not just a healer; she was a warrior in her own right, and she was fighting her own battles. He took her hand, his touch a silent promise. He would not let her fight alone.</p>
+</div>
+<div id="page-122" class="page-content-container">
+    <h2>Chapter 9: The Ruins of Vajradan</h2>
+    <p>Arjun carried the wounded and humiliated Anirudh not to a healer, but to the Ruins of Vajradan, a city of shattered towers and sleeping magic, a place where his father had once learned to master the elements. "You fought the void with fire," Arjun said, his voice echoing in the vast, silent halls. "But you cannot burn a vacuum. To defeat the void, you must understand it. And to understand it, you must face the ultimate emptiness: death itself." He led Anirudh to a sealed chamber at the heart of the ruins, a place that hummed with a terrifying, latent power.</p>
+</div>
+<div id="page-123" class="page-content-container">
+    <h2>Chapter 10: Facing the Void</h2>
+    <p>"This chamber will show you your own end," Arjun explained. "It will strip away everything you are. You must find the spark that remains, or be consumed forever." Inside, Anirudh's world dissolved. He was pulled into a harrowing, vivid vision of his father's last moments. He saw the council chamber, felt the sting of betrayal as Kavrik, his father's sworn brother, stepped aside, allowing the assassins to strike. He heard his father's final, defiant words. He felt his father's life extinguish.</p>
+</div>
+<div id="page-124" class="page-content-container">
+    <h2>Chapter 11: The Vayu Vajra Ascendant</h2>
+    <p>Anirudh did not just see it; he lived it. He screamed, not in his mind, but in the chamber, a sound of pure, elemental grief and rage. And from that crucible of loss, a new power was born. He emerged from the chamber not just alive, but reborn in golden fire. The Vayu Vajra Ascendant Form crackled around him, a cloak of lightning and wind, a power so immense it threatened to tear his own body apart even as it obeyed his will. He had touched death, and returned with its power.</p>
+</div>
+<div id="page-125" class="page-content-container">
+    <h2>Chapter 12: The Siege of Kanjiram</h2>
+    <p>They returned to the council to find chaos. The Shadow Faction, emboldened, had thrown their full might at Kanjiram Academy, a brazen declaration of war. A tide of corrupted wild beasts, their eyes glowing with malevolent purple light, crashed against the academy walls. The siege was a maelstrom of chaos and terror.</p>
+</div>
+<div id="page-126" class="page-content-container">
+    <h2>Chapter 13: The Golden Comet</h2>
+    <p>Anirudh, now a warrior transformed, became the eye of the storm. His Ascendant Form was a golden comet on the battlefield, a beacon of impossible hope against the encroaching darkness. He moved with the speed of thought, his every strike a thunderclap, single-handedly turning the tide at the main gate by felling a monstrous Flamehorn Rhino that had shattered the ancient defenses.</p>
+</div>
+<div id="page-127" class="page-content-container">
+    <h2>Chapter 14: The Silver Angel</h2>
+    <p>Meera, her heritage now revealed, became a silver angel on the battlefield. She moved through the wounded, her hands glowing, knitting together flesh and bone, her very presence a shield against the creeping shadows of despair. She was not just a healer; she was a symbol of defiance, a testament to the fact that even in the darkest of times, the light of life could not be extinguished.</p>
+</div>
+<div id="page-128" class="page-content-container">
+    <h2>Chapter 15: The Beast King</h2>
+    <p>But the enemy had held back their trump card. From the heart of their army, a creature of nightmare emerged: the Obsidian Direwolf, a Beast King of shadow and moonlight, its howl a promise of death. It ignored the chaos, its intelligent, malevolent eyes fixing on the golden comet in the main courtyard. It had found its prey.</p>
+</div>
+<div id="page-129" class="page-content-container">
+    <h2>Chapter 16: A Duel of Myths</h2>
+    <p>The world seemed to hold its breath. The duel was not just a fight; it was a clash of mythic forces. The Direwolf was a living shadow, cloaking itself in darkness to strike from unseen angles, its claws dripping with energy-draining void magic. Anirudh, in his Ascendant Form, was a being of pure, golden light, but he could feel his energy draining, the immense power of the form taking its toll. He was burning out.</p>
+</div>
+<div id="page-130" class="page-content-container">
+    <h2>Chapter 17: The Alchemist's Legacy</h2>
+    <p>Pushed to his absolute limit, his mind raced back to the dusty, forgotten tomes in the library, to the theories of his father. He began to weave intricate, glowing alchemical seals into the air with his free hand, a skill inherited, but never mastered. A seal of Binding to counter the beast's phasing. A seal of Purity to negate its regenerative abilities. The duel shifted from a brawl to a deadly, high-speed chess match. The odds were evened, but Anirudh knew it wasn't enough. He was fading.</p>
+</div>
+<div id="page-131" class="page-content-container">
+    <h2>Chapter 18: The Final Gamble</h2>
+    <p>He made a final, desperate gamble. He drew upon the teachings of the incomplete Death-Resurrection Scroll, a forbidden technique that traded life for absolute power. He channeled his own life force, his very essence, into one, final, cataclysmic strike. "VAYU VAJRA!" he roared, his voice the sound of a star being born. He became a golden meteor, striking the Direwolf with the force of a falling mountain. The beast, and the entire courtyard, were consumed by a blinding, silent explosion of golden light.</p>
+</div>
+<div id="page-132" class="page-content-container">
+    <h2>Chapter 19: The Silence and the Spark</h2>
+    <p>When the light faded, Anirudh lay at the center of a crater, his body still, the golden light of his Ascendant Form extinguished. His heart had stopped. For three long minutes, he was dead. The battle ground to a halt, friend and foe alike staring in stunned silence. And then, Meera reached him. With tears streaming down her face, she poured her own life force, her Moonblood essence, into his still form, a desperate, loving prayer against the encroaching darkness. His heart sputtered, then beat once. Then again. He had won, but at a cost that had nearly shattered them all.</p>
+</div>
+<div id="page-133" class="page-content-container">
+    <h2>Chapter 20: The Weight of Truth</h2>
+    <p>In the quiet aftermath, amidst the scent of ozone and healing herbs, Arjun sat by Anirudh's bedside and finally unburdened his soul. He told him everything. That his father, Raghav, was not just a great warrior, but the last Alchemist King. He explained that Meera's family were not just villagers, but the sworn guardians of the king's bloodline. And then came the final, devastating blow. Kavrik, the master of the void, the man who had defeated him, the man who had betrayed his father... was once Raghav's most beloved friend, his sworn brother, his most trusted ally. The betrayal was not political; it was personal, a wound that had festered for fifteen years. Anirudh listened, his expression hardening from stone to diamond. The grief, the anger, the loss... it all coalesced into a single point of cold, clear, and absolute resolve. He would not just defeat the Shadow Faction. He would find Kavrik, and he would erase the stain of his betrayal from the world. Word of the impossible victory at Kanjiram spread like wildfire, but it did not bring peace. The Whisperer used the brazen attack to whip the other factions into a frenzy of fear and paranoia. Armies, once held in reserve, began to muster. A final, cataclysmic battle was now inevitable, the stage set in the desolate, cursed landscape of the Valley of Blood Moons.</p>
+</div>
+<!-- ACT 7: THE VALLEY OF BLOOD MOONS -->
+<div id="page-134" class="page-content-container">
+    <h1>Act 7: The Valley of Blood Moons</h1>
+    <h2>Chapter 1: The Crimson Fields</h2>
     <p>The ground trembled long before the armies clashed. It was a low, guttural vibration that rose through the soles of Anirudh’s boots and settled deep in his bones, a promise of the carnage to come. He stood on a small rise, the banners of the allied armies snapping in the ash-filled wind behind him. Before him, the enemy was a dark, screaming stain on the horizon, a horde of fanatics and twisted, Void-touched beasts. Meera found him there, her silver light a soft, gentle glow against the bloody moonlight. "They are afraid," she said, her voice quiet. "I was talking about our own men." She gestured to a makeshift field hospital, where a young soldier, his face pale, his hand trembling as he clutched a letter, looked up at them. "His name is Kael," Meera said softly. "He has a wife, and a daughter he has never met. He's fighting for them."</p>
     <p>Her words cut through Anirudh's own internal storm. He walked over to the soldier. "Kael," he said, his voice steady. The soldier looked up, startled. "You will see your daughter," Anirudh said, his gaze unwavering. "I promise." The words were not just for the soldier. They were for him. He was not just here to avenge his father. He was here for them. The thought was a sudden, sharp clarity. It did not banish his fear, but it gave it purpose. The horns blew. The world erupted.</p>
+</div>
+<div id="page-135" class="page-content-container">
+    <h2>Chapter 2: The Tide of Battle</h2>
     <p>The initial impact was a brutal, grinding pulverization of flesh and steel. Anirudh fought in the heart of it, a golden whirlwind of destruction. His first true test was Vorlag the Void-touched, a hulking brute whose skin was like cracked obsidian and whose spear seemed to drink the light. The duel was a dance in a hurricane. Anirudh's staff, a gift from Arjun, turned to black, crumbling rot in his hands as it parried a blow from the void-spear. Disarmed, he was forced into a desperate defense. He slapped his own arms, his chest, his legs, his hands a blur as he traced the glowing alchemical seals of hardening, his skin taking on a golden, metallic sheen. He met the spear not with a weapon, but with his own body. Each blocked blow sent a tremor of black, corrosive energy through him, a pain that was a cold, numbing echo of the void itself. He won, but was left drained and wounded, the victory a stark reminder of the greater battle to come.</p>
-
-    <h3>Chapter 2: The Ghost on the Cliff</h3>
+</div>
+<div id="page-136" class="page-content-container">
+    <h2>Chapter 3: The Ghost on the Cliff</h2>
     <p>High above the battlefield, on a lonely, windswept cliff, Kavrik waited. "He screamed your name at the end, you know," he said as Anirudh arrived, his voice a soft, conversational poison. "Begged me to spare his 'innocent child'. He died believing in innocence. Such a fool." Rage, hot and blinding, surged through Anirudh, but he fought it down, hardening it into a core of pure, cold resolve. "My father died believing in a friend," Anirudh said, his voice dangerously quiet. "He was not the fool in that friendship."</p>
     <p>"Friendship? Hope? Love?" Kavrik laughed, a dry, rasping sound. "They are chains. The attachments of the weak. The Void is pure. It is honest. It offers true strength, free from the sentiment that made your father weak. Join me, Anirudh. You have felt its power. Embrace your true potential."</p>
-    <p>"My father believed in people," Anirudh countered, his Vayu Vajra form igniting around him in a swirl of golden energy. "He believed in hope. That is a strength your empty world can never comprehend. I am not him. I am his son. And I will not make his mistake. I will not trust a serpent." The duel was a clash of ideologies made manifest. Kavrik's void style was nihilism, a vortex of life-draining energy. Anirudh's Vayu Vajra was life, a storm of golden light and furious hope.</p>
-    <p>The fight escalated when Kavrik summoned Shadow Doppelgangers, spectral horrors that took the form of Anirudh's parents, their voices whispering his deepest fears. "You let us die," the shade of his mother whispered. "You are not strong enough," the ghost of his father accused. Pushed to the brink, his heart breaking with every parry against the faces of those he loves, Anirudh unleashed the forbidden Death-Resurrection Style, not in anger, but in a desperate, sacrificial burst of life force that annihilated the shadows. The cost was immense, leaving him on the verge of collapse. Kavrik seized the opportunity, plunging the world into an 'Eternal Eclipse'. In the suffocating, sense-depriving darkness, Anirudh fought on pure instinct, guided by a single thread of silver light he could feel from the battlefield below—Meera. His final strike was a flash of golden lightning that shattered the void and broke Kavrik's blades. Defeated but unrepentant, Kavrik escaped in a mist of shadows, leaving behind a pulsating Void-touched token. "You have won nothing," his voice echoed. "The council room is where your blood will spill."</p>
-
-    <h3>Chapter 3: The Serpent's Kiss</h3>
-    <p>The victory celebration in the war council tent was a brief, fragile thing. Lord Varash, his face a mask of grandfatherly pride, raised a toast. "To Anirudh, the hero of Kanjiram!" he boomed, his voice full of false cheer. Then, his expression hardened, and he turned on Anirudh, holding up the Void-touched token Kavrik had left behind. "A hero... or a shadow infiltrator! I found this on the battlefield. Proof of a pact between this boy and the enemy!"</p>
+    <p>"My father believed in people," Anirudh countered, his Vayu Vajra form igniting around him in a swirl of golden energy. "He believed in hope. That is a strength your empty world can never comprehend. I am not him. I am his son. And I will not make his mistake. I will not trust a serpent."</p>
+</div>
+<div id="page-137" class="page-content-container">
+    <h2>Chapter 4: The Serpent's Kiss</h2>
+    <p>The duel was a clash of ideologies made manifest. Kavrik's void style was nihilism, a vortex of life-draining energy. Anirudh's Vayu Vajra was life, a storm of golden light and furious hope. The fight escalated when Kavrik summoned Shadow Doppelgangers, spectral horrors that took the form of Anirudh's parents, their voices whispering his deepest fears. "You let us die," the shade of his mother whispered. "You are not strong enough," the ghost of his father accused. Pushed to the brink, his heart breaking with every parry against the faces of those he loves, Anirudh unleashed the forbidden Death-Resurrection Style, not in anger, but in a desperate, sacrificial burst of life force that annihilated the shadows. The cost was immense, leaving him on the verge of collapse. Kavrik seized the opportunity, plunging the world into an 'Eternal Eclipse'.</p>
+</div>
+<div id="page-138" class="page-content-container">
+    <h2>Chapter 5: The Light in the Dark</h2>
+    <p>In the suffocating, sense-depriving darkness, Anirudh fought on pure instinct, guided by a single thread of silver light he could feel from the battlefield below—Meera. His final strike was a flash of golden lightning that shattered the void and broke Kavrik's blades. Defeated but unrepentant, Kavrik escaped in a mist of shadows, leaving behind a pulsating Void-touched token. "You have won nothing," his voice echoed. "The council room is where your blood will spill."</p>
+</div>
+<div id="page-139" class="page-content-container">
+    <h2>Chapter 6: The Serpent's Head</h2>
+    <p>Anirudh returned to the main battle, exhausted but resolute. He knew Kavrik was just a symptom. The true poison was The Whisperer, and their master, Lord Varash. He found them in the main command tent, surrounded by the elite of the Alchemy Order. The victory celebration was a brief, fragile thing. Lord Varash, his face a mask of grandfatherly pride, raised a toast. "To Anirudh, the hero of Kanjiram!" he boomed, his voice full of false cheer. Then, his expression hardened, and he turned on Anirudh, holding up the Void-touched token Kavrik had left behind. "A hero... or a shadow infiltrator! I found this on the battlefield. Proof of a pact between this boy and the enemy!"</p>
+</div>
+<div id="page-140" class="page-content-container">
+    <h2>Chapter 7: The Betrayal</h2>
     <p>Before the stunned council could react, assassins from the Alchemy Order, hidden amongst the delegates, struck. The tent erupted into chaos. The General of the Martial Clans was cut down, his honor guard overwhelmed. Arjun, a lion in winter, moved to protect Anirudh, felling the first wave of assassins with a furious grace. But then, a single, poisoned blade, thrown from the back of the tent, found its mark. Arjun gasped, stumbling, a dozen more blades finding him in his moment of weakness. He fell, his last words a desperate, choked plea to Anirudh: "Don't... let the rage... consume you. Be... the key... not... the hammer..."</p>
-
-    <h3>Chapter 4: The God of Rage</h3>
+</div>
+<div id="page-141" class="page-content-container">
+    <h2>Chapter 8: The God of Rage</h2>
     <p>Seeing his master fall, something inside Anirudh shattered. The world dissolved into a silent, white-hot scream of pure, untamed, agonizing rage. His body twisted, bones breaking and reforming with sickening cracks, as the raw, elemental power he had struggled to control exploded outward. He was a prisoner in his own mind, a helpless observer as his body became a vessel for something terrible and ancient. *No... no, stop...* he screamed, but his voice was only the roar of the storm. He saw the terror on the faces of his own allies as the Stormbeast, a being of obsidian skin and crackling lightning, a god of pure, agonizing fury, unleashed its indiscriminate wrath.</p>
+</div>
+<div id="page-142" class="page-content-container">
+    <h2>Chapter 9: The Anchor</h2>
     <p>He felt his consciousness slipping away, drowning in an ocean of rage. But then, a single, soft, silver light pushed through the maelstrom. Meera. She walked into the heart of the storm, her own power a fragile, defiant shield against the raging elements. She did not shout. She did not command. She whispered his name. "Anirudh," she said, her voice a lifeline, a thread of memory and hope in the hurricane of his rage. "I'm here. Come back. Remember your promise. Remember Kael." The beast roared, lashing out, but the man inside, hearing her voice, began to fight back.</p>
-
-    <h3>Chapter 5: The Alchemist's End</h3>
+</div>
+<div id="page-143" class="page-content-container">
+    <h2>Chapter 10: The Alchemist's End</h2>
     <p>The final confrontation with Varash was a battle for Anirudh's soul. "You cannot control it, boy!" Varash screamed, his own form crackling with the borrowed power of the Crimson Philosopher's Stone he held in his hand. "But I can teach you! Together, we can be gods! We will cleanse this world with fire and build a new one, an orderly one, from the ashes!" The temptation of control, of purpose for his pain, was a siren's call. But in the storm of his mind, Anirudh saw the faces of those he loved: his mother's sacrifice, Arjun's final plea, Meera's unwavering faith. He chose to be a man.</p>
     <p>With a serene, impossible clarity, he did not fight the storm within him. He guided it. He wove his father's Three Seal Harmony Technique, a style of balance and control, with the raw, chaotic power of the Stormbeast. He was not just using two styles; he had created a new one, a perfect synthesis of wisdom and power, of rage and purpose. He became a living conduit of focused, controlled energy. He did not strike Varash. He struck the Crimson Philosopher's Stone. The stone, unable to contain the raw, purified power of a living storm, overloaded. With a deafening, silent explosion, Varash and his ambition were obliterated, erased from existence.</p>
-
-    <h3>Epilogue: The Weight of the Dawn</h3>
-    <p>In the weeks that followed, a new council was formed from the ashes of the old. Arjun, crippled but alive, his healing aided by Meera's tireless efforts, sat with Anirudh on the same windswept balcony. He pressed his own sword into Anirudh's hands. "The master's journey is over," Arjun said, his voice weak but steady. "The hero's has just begun. Do not try to be perfect, Anirudh. Just try to be good."</p>
-    <p>Under a peaceful moon, Anirudh and Meera stood before a simple, unmarked stone they had erected for his father. "I'm sorry it took me so long," Anirudh whispered to the stone, his hand resting on its cool surface. "I understand now. Power isn't a weapon. It's a shield. It isn't what I inherited that matters. It's what I choose to protect. I will try... to be a man worthy of your memory." Meera took his hand, her fingers lacing with his, a silent promise of a shared future, a shared burden, a shared hope.</p>
-    <p>He looked out at the peaceful world, his heart calm, his purpose clear. But as the camera pulls back, a colossal shadow falls over a distant mountain range. A slumbering titan, its form so vast it is mistaken for a mountain itself, has been awakened by the echoes of their battle. It turns its ancient, stony head towards the lands of men, its eyes, two points of cold, ancient light, blinking open for the first time in millennia. The war was over. The age of monsters was just beginning.</p>
 </div>
+<div id="page-144" class="page-content-container">
+    <h2>Chapter 11: The Cost of Victory</h2>
+    <p>As Varash turned to dust, the power of the Crimson Philosopher's Stone, now unstable, lashed out. A wave of raw, chaotic energy erupted from the fading light, striking the wounded Arjun. Meera screamed, rushing to his side, her own light battling the corrosive energy that threatened to consume him. Anirudh, his own power spent, could only watch in horror as the two people he loved most fought for their lives.</p>
+</div>
+<div id="page-145" class="page-content-container">
+    <h2>Chapter 12: The Long Road to Dawn</h2>
+    <p>The weeks that followed were a blur of pain and healing. The war was over, but the victory felt hollow. Arjun was alive, but crippled, the void-poison a permanent, chilling echo in his limbs. Meera had exhausted her own life force to save him, and her light was now a faint, flickering candle. The world was saved, but his small world was shattered.</p>
+</div>
+<div id="page-146" class="page-content-container">
+    <h2>Chapter 13: The New Council</h2>
+    <p>From the ashes of the old, a new council was formed. The delegates, humbled and weary, looked to Anirudh not with suspicion, but with a new, fragile hope. They offered him a seat at the council, a position of power. He refused. "My place is not in a council room," he said, his voice quiet but firm. "It is out there, with the people, helping to rebuild what was broken."</p>
+</div>
+<div id="page-147" class="page-content-container">
+    <h2>Chapter 14: A Brother's Return</h2>
+    <p>Rohan, who had fought bravely in the final battle, approached Anirudh. The arrogance was gone, replaced by a quiet respect. "I was wrong about you," he admitted, his voice stiff with the unfamiliar taste of humility. "I saw a hammer, and I thought you were a nail. But you were the forge all along." He offered his sword, and his loyalty, to Anirudh. The rivalry was over, replaced by a bond forged in the fires of war.</p>
+</div>
+<div id="page-148" class="page-content-container">
+    <h2>Chapter 15: The Weight of a Sword</h2>
+    <p>In the quiet of the healing chambers, Arjun pressed his own sword into Anirudh's hands. It was a simple, elegant blade, but it felt heavier than a mountain. "The master's journey is over," Arjun said, his voice weak but steady. "The hero's has just begun. Do not try to be perfect, Anirudh. Just try to be good."</p>
+</div>
+<div id="page-149" class="page-content-container">
+    <h2>Chapter 16: A Father's Grave</h2>
+    <p>Under a peaceful moon, Anirudh and Meera stood before a simple, unmarked stone they had erected for his father. "I'm sorry it took me so long," Anirudh whispered to the stone, his hand resting on its cool surface. "I understand now. Power isn't a weapon. It's a shield. It isn't what I inherited that matters. It's what I choose to protect. I will try... to be a man worthy of your memory."</p>
+</div>
+<div id="page-150" class="page-content-container">
+    <h2>Chapter 17: A Quiet Promise</h2>
+    <p>Meera took his hand, her fingers lacing with his. Her light was still faint, but it was steady, and it was warm. "You are not alone, Anirudh," she said, her voice a quiet promise. "You never were." He looked at her, at the unwavering faith in her eyes, and he felt a sense of peace he had never known before. The rage was gone, the grief was quiet. All that was left was a shared hope for the future.</p>
+</div>
+<div id="page-151" class="page-content-container">
+    <h2>Chapter 18: The Seeds of a New Age</h2>
+    <p>In the months that followed, Anirudh, Meera, and Rohan traveled the land, not as warriors, but as builders. They helped to replant the fallow fields, to rebuild the shattered villages, to mend the broken hearts of a world scarred by war. Anirudh used his father's alchemical knowledge not to create weapons, but to purify the land, to bring life back to the places the void had touched.</p>
+</div>
+<div id="page-152" class="page-content-container">
+    <h2>Chapter 19: The Whispering Mountain</h2>
+    <p>But the world was not entirely at peace. On a distant mountain range, a colossal shadow shifted. A slumbering titan, its form so vast it was mistaken for the mountain itself, had been awakened by the echoes of their battle. It turned its ancient, stony head towards the lands of men, its eyes, two points of cold, ancient light, blinking open for the first time in millennia.</p>
+</div>
+<div id="page-153" class="page-content-container">
+    <h2>Chapter 20: The Age of Monsters</h2>
+    <p>The war was over. The age of monsters was just beginning. Anirudh, standing on a hill overlooking a peaceful, rebuilding valley, felt the tremor in the earth. He looked to the horizon, his eyes narrowed, his hand instinctively going to the hilt of Arjun's sword. He was not afraid. He was ready. The hero's journey was far from over. It was just beginning.</p>
 </div>
     </main>
 </body>


### PR DESCRIPTION
I've completed the full 7-act story of "Child of the Crimson Pendant".

This includes the previously added "Scroll Hunt" arc (Acts 2-4) and the newly expanded final three acts (Acts 5-7).

Based on the content you provided, I expanded Acts 5, 6, and 7 to 20 chapters each, adding new creative writing to flesh out the narrative.

The story is now a complete, epic tale, ready for your final review.