### PR TITLE
feat: Expand and enhance the story content

### DIFF
--- a/blueprint.md
+++ b/blueprint.md
@@ -1,117 +1,36 @@
-# Flames of Destiny - Anirudh's Journey
+# Child of the Crimson Pendant - Story Enhancement
 
 ## Project Overview
 
-## Website Structure and Navigation
+This project aims to enhance the story "Child of the Crimson Pendant" contained in `index.html`. The goal is to enrich the narrative by adding more content, conversations, and emotional depth to the existing chapters, making the story more immersive for the reader. This will include introducing new characters and subplots to create a more in-depth story.
 
-To improve the user experience and make the story easily navigable, a navigation bar has been added to the top of each HTML story page. This navigation bar includes links to the "Previous Page" and "Next Page", allowing readers to move sequentially through the narrative. The styling for the navigation bar is handled within the `style.css` file, providing a consistent and visually appealing appearance across all pages.
+## Current State
 
+The `index.html` file contains a complete, multi-act story following the journey of Anirudh. The user has requested a significant expansion of the content.
 
-## Project Overview
+## Plan for Enhancement
 
-This project aims to expand the provided story plot for "Flames of Destiny - Anirudh's Journey" into a 1000-page narrative presented as a website. The story is a fantasy action-adventure with elements of romance, focusing on Anirudh's journey from an orphaned academy recruit to a powerful fighter.
+The enhancement will be performed iteratively, act by act, to ensure the changes align with the user's vision.
 
-## Current Story Outline (Act 1: The Awakening)
+### 1. Restore Act 1
+- **Objective:** Revert previous edits to `index.html` to start fresh.
+- **Action:** Use the `restore_file` tool to bring `index.html` back to its original state.
 
-### SCENE 1: The Orphan’s Struggle
-*   Introduces young Anirudh seeking entry into the academy.
-*   Highlights his determination and lack of background.
-*   Master Guruji challenges him to prove himself.
+### 2. Re-Expand Act 1
+- **Objective:** Rewrite Act 1 with a focus on adding more in-depth content.
+- **Details:**
+    - **Introduce a new character:** Introduce an elderly woman from the village who shows kindness to Anirudh, creating opportunities for new dialogue and showing a different side of his life.
+    - **Expand on existing characters:** Add more dialogue and internal thoughts for Anirudh, Rohan, and the instructors to make them more complex.
+    - **Add more descriptive detail:** Add more details to the world, the academy, and the trials to make the story more immersive.
 
-### SCENE 2: The First Battle - Humiliation
+### 3. Review the new Act 1 with you
+- **Objective:** Get feedback on the changes made to Act 1.
+- **Action:** After re-expanding Act 1, I will ask the user for feedback to ensure the new content meets their expectations before proceeding.
 
-*   Anirudh (age 15) faces Veer, a powerful and arrogant student.
-*   Anirudh is easily defeated and humiliated by Veer.
-*   Meera observes with sympathy, noting Anirudh's heart but lack of technique.
-*   Anirudh's defiant request for a rematch surprises the crowd.
+### 4. Expand Subsequent Acts (Acts 2-7)
+- **Objective:** Continue expanding the story based on user feedback.
+- **Action:** I will apply the same process of adding content and dialogue to the remaining acts of the story, focusing on character development, world-building, and emotional impact.
 
-### SCENE 3: The Secret Mentor
-
-*   Anirudh is approached by Arjun, a rogue fighter.
-*   Arjun offers to mentor Anirudh, seeing potential in him.
-*   Anirudh accepts Arjun's guidance.
-
-### SCENE 4: The Love That Grows
-*   Montage of Anirudh's training with Arjun, focusing on advanced techniques.
-*   Montage of Anirudh's training with Arjun, focusing on advanced techniques.
-*   Anirudh's interactions with Meera increase as she treats his injuries.
-*   Their relationship deepens through shared moments and understanding.
-
-### SCENE 5: The Shadow Panther Battle
-
-*   Anirudh faces his first major challenge in the underground arena: a Shadow Panther.
-*   He uses Arjun's teachings and his instincts to defeat the beast with a new technique (The Rising Sun Fist).
-*   The victory earns him recognition.
-
-## Expanded Act 1: Child of the Crimson Pendant
-
-Act 1, "Child of the Crimson Pendant," will be expanded from the initial 10-page outline to a total of 50 HTML pages.
-
-This expansion will involve adding numerous new scenes, dialogues, action sequences, and moments of character reflection to build a rich and extensive narrative. The goal is to significantly flesh out the events and character development outlined in the initial 10 pages, providing a much deeper and more immersive experience for the reader.
-
-*   **Page 1:** Opening Scene: The Storm - The birth of Anirudh and his mother's sacrifice.
-*   **Page 2:** 15 Years Later - Anirudh's training and determination outside the academy.
-*   **Page 3:** Academy Entrance - Anirudh faces scrutiny and disdain at the academy gates.
-*   **Page 4:** The Trial Grounds - Anirudh participates in the grueling initiation trials.
-*   **Page 5:** Accepted - Anirudh learns he has been accepted, placing tenth.
-*   **Page 6:** The Whisper of Legends - Anirudh discovers a book with the symbol from his pendant.
-*   **Page 7:** Introduction of Arjun - The powerful master Arjun is introduced.
-*   **Page 8:** Secret Mentor - Arjun approaches Anirudh and offers guidance.
-*   **Page 9:** The Bond Begins - A training montage shows Anirudh learning from Arjun and the reveal of his father's identity.
-*   **Page 10:** End of Act 1: Destiny Awakened - Anirudh embraces his destiny and heads into the forest.
-
-## Plan for Expansion (Towards 1000 Pages)
-
-To reach a target length of 1000 pages, we will significantly expand upon the existing plot and introduce new elements. Key areas of focus will include:
-
-1.  **More Intense Training Sequences:** Detail Anirudh's rigorous training under Arjun, showcasing the mastery of new techniques, pushing his physical and alchemic limits, and overcoming internal struggles. This will involve multiple training arcs focusing on different skills (speed, strength, alchemic control, strategy, etc.).
-
-2.  **Introducing Multiple Levels of Opponents and Battles:** Anirudh will face a wider variety of opponents, increasing in skill and power. These will include:
-    *   More challenging academy students.
-    *   Fighters from rival academies or factions.
-    *   Wild beasts and monsters.
-    *   Individuals with unique fighting styles and alchemic abilities.
-    *   Gradual introduction of lieutenants and allies of the main antagonist.
-
-3.  **Developing Deeper Relationships with Meera and Arjun:**
-    *   **Meera:** Explore the evolving romance between Anirudh and Meera. Show their mutual support, challenges to their relationship (academy rules, external threats), and how their bond strengthens them. Meera's role as a healer and potential alchemist will be explored further.
-    *   **Arjun:** Delve into Arjun's past and motivations. Reveal more about his rogue status and his connection to the academy or the wider world. Explore the master-student dynamic and how Anirudh's progress impacts Arjun.
-
-4.  **Expanding the Lore of the Academy and Hidden Martial Arts Techniques:**
-    *   Detail the history and hierarchy of the academy.
-    *   Introduce other masters and their specialties.
-    *   Explore the origins and variations of alchemic energy and martial arts in this world.
-    *   Introduce ancient or forbidden techniques that Anirudh might discover or develop.
-    *   Explore the political landscape surrounding the academy and its role in the kingdom/world.
-
-## Plan for Expansion (Towards 1000 Pages)
-
-To reach a target length of 1000 pages, we will significantly expand upon the existing plot and introduce new elements. Key areas of focus will include:
-
-1.  **More Intense Training Sequences:** Detail Anirudh's rigorous training under Arjun, showcasing the mastery of new techniques, pushing his physical and alchemic limits, and overcoming internal struggles. This will involve multiple training arcs focusing on different skills (speed, strength, alchemic control, strategy, etc.).
-
-2.  **Introducing Multiple Levels of Opponents and Battles:** Anirudh will face a wider variety of opponents, increasing in skill and power. These will include:
-    *   More challenging academy students.
-    *   Fighters from rival academies or factions.
-    *   Wild beasts and monsters.
-    *   Individuals with unique fighting styles and alchemic abilities.
-    *   Gradual introduction of lieutenants and allies of the main antagonist.
-
-3.  **Developing Deeper Relationships with Meera and Arjun:**
-    *   **Meera:** Explore the evolving romance between Anirudh and Meera. Show their mutual support, challenges to their relationship (academy rules, external threats), and how their bond strengthens them. Meera's role as a healer and potential alchemist will be explored further.
-    *   **Arjun:** Delve into Arjun's past and motivations. Reveal more about his rogue status and his connection to the academy or the wider world. Explore the master-student dynamic and how Anirudh's progress impacts Arjun.
-
-4.  **Expanding the Lore of the Academy and Hidden Martial Arts Techniques:**
-    *   Detail the history and hierarchy of the academy.
-    *   Introduce other masters and their specialties.
-    *   Explore the origins and variations of alchemic energy and martial arts in this world.
-    *   Introduce ancient or forbidden techniques that Anirudh might discover or develop.
-    *   Explore the political landscape surrounding the academy and its role in the kingdom/world.
-
-5.  **Setting Up the Main Antagonist and Overarching Conflict:**
-    *   Introduce hints and signs of a larger threat.
-    *   Gradually reveal the main antagonist's identity, goals, and power.
-    *   Establish the stakes of the overarching conflict and how it connects to Anirudh, the academy, and possibly Meera and Arjun.
-    *   Build suspense and anticipation for the confrontation with the antagonist.
-
-This expansion will involve adding numerous new scenes, dialogues, action sequences, and moments of character reflection to build a rich and extensive narrative.
+### 5. Final Review
+- **Objective:** Ensure the entire story is consistent and flows well.
+- **Action:** After all acts have been expanded, I will perform a final read-through of the entire `index.html` file to check for any inconsistencies or areas that need further refinement.

--- a/index.html
+++ b/index.html
@@ -11,198 +11,95 @@
         <h1>Child of the Crimson Pendant</h1>
     </header>
     <main>
-<div id="page-1" class="page-content-container">
+<div id="page-1-5-reexpanded" class="page-content-container">
+    <div class="scene">
         <p class="setting">INSIDE A SMALL HUT – NIGHT</p>
-        <p>The wind howled like a hungry wolf, tearing at the weak walls of the hut. Heavy rain beat down on the thatched roof, threatening to collapse it. Inside, the air was thick with the smell of wet earth and fear. A young woman, her face pale and streaked with tears, lay on a simple cot. Her breath was shallow, but her eyes were fixed on the small baby in her arms.</p>
+        <p>The wind howled like a hungry wolf, tearing at the weak walls of the hut. Heavy rain beat down on the thatched roof, threatening to collapse it. Inside, the air was thick with the smell of wet earth and fear. A young woman, her face pale and streaked with tears, lay on a simple cot. Her breath was shallow, but her eyes were fixed on the small baby in her arms. She hummed a quiet, sad lullaby, a tune of lost kingdoms and forgotten magic.</p>
         <img src="https://raw.githubusercontent.com/google/gemini-micro-materials/main/images/stormy_hut.jpg" alt="A crumbling hut in a violent storm" class="story-image">
         <p class="character">WOMAN</p>
-        <p class="dialogue">(whispering, her voice cracking) Anirudh... my little warrior. Forgive me. I cannot protect you anymore.</p>
-        <p class="action">Her shaking fingers reached for a heavy copper chain around her neck. On it hung a round pendant, etched with a swirling, ancient symbol. As her fingers closed around it, the symbol pulsed with a soft, golden light, pushing back against the shadows in the hut.</p>
-        <p class="action">With the last of her strength, she placed the chain over the baby’s head. The cool metal rested against his skin, and the pendant’s glow seemed to brighten, covering him in a protective light.</p>
+        <p class="dialogue">(whispering, her voice cracking) Anirudh... my little warrior. My brave boy. Forgive me. I cannot protect you anymore. The darkness is too strong.</p>
+        <p class="action">Her shaking fingers reached for a heavy copper chain around her neck. On it hung a round pendant, etched with a swirling, ancient symbol. It was warm to the touch, a familiar comfort in the encroaching cold. As her fingers closed around it, the symbol pulsed with a soft, golden light, pushing back against the shadows in the hut.</p>
+        <p class="character">WOMAN</p>
+        <p class="dialogue">(Her voice gaining a faint strength from the pendant's glow) This was your father's. He forged it in the heart of a dying star. It holds his courage, his wisdom... and his love for you. It will be your shield.</p>
+        <p class="action">With the last of her strength, she placed the chain over the baby’s head. The cool metal rested against his skin, and the pendant’s glow seemed to brighten, covering him in a protective light. He cooed softly, his tiny hand reaching up to touch the warm, glowing symbol.</p>
         <p class="character">WOMAN (V.O.)</p>
-        <p class="dialogue">Your father’s blood flows in you. The blood of the Alchemist King. They will hunt you for it. But you must live... you must survive.</p></div>
-<div id="page-2" class="page-content-container">
- <div class="scene">
- <img src="https://via.placeholder.com/800x600?text=Stormy+Night+Hut" alt="A hut battered by a storm">
- <div class="narration">
- The storm raged, and the woman’s breath grew weaker. She held her baby, Anirudh, with all her might.
- </div>
- <div class="character-dialogue">
- <span class="character">WOMAN</span>
- <span class="dialogue">(her voice a faint whisper) Don't let their darkness touch you... Carry the light... Find your strength...</span>
- </div>
- <div class="narration">
- A loud crash of thunder shook the hut, and the flimsy door was thrown open. A figure stood in the doorway, tall and completely hidden by a dark, heavy cloak. No face could be seen, only shadow, but a feeling of cold, deadly intent filled the small room. The woman gasped, her last hope gone. The cloaked figure stepped inside, and her world went black.
- </div>
- </div>
-</div>
-<div id="page-3" class="page-content-container">
-<div class="scene">
-    <h1>Act 1: The Spark</h1>
-    <h2>The Orphan of Kanjiram</h2>
-    <p class="setting">FIFTEEN YEARS LATER - OUTSIDE KANJIRAM ACADEMY – MORNING</p>
-    <p>Fifteen years of hardship had forged Anirudh into a living weapon, a prodigy of raw power and untamed spirit. He was a phantom in the early morning mist, a blur of motion against the ancient stones of the academy wall. The name Anirudh was a whisper on the wind, a legend in the making, though he himself was oblivious to it. Now a young man of fifteen, his body was a testament to a will of iron; lean, powerful, with every muscle honed to a razor's edge by years of relentless, self-imposed training that bordered on obsession. His eyes, dark and intense, held a fire that burned with the heat of a thousand suns, a stark rebellion against the tranquil morning. He wore simple, patched clothes, not as a sign of poverty, but as a declaration that his worth was not measured in silks or gold, but in the strength of his spirit. This made him an anomaly, a stark contrast to the pampered students who trained within the gilded walls of the famous Kanjiram Academy.</p>
-    <img src="https://via.placeholder.com/600x400?text=Anirudh+Training" alt="Anirudh training with a staff">
-    <p>He gripped a heavy wooden staff, its surface a roadmap of his struggle, battered and splintered from countless strikes against unyielding foes, both real and imagined. He moved with a raw, explosive grace that no formal training could ever hope to replicate. This was not the elegant dance of a pampered student; it was the ferocious, beautiful, and deadly style of a true survivor, of someone who had clawed his way back from the brink and fought for every breath. He attacked a thick oak tree as if it were the embodiment of his destiny, his jaw set with a ferocious determination that was both inspiring and terrifying to behold. He was not just practicing; he was sculpting his soul, preparing for a war he knew was coming, a war he was born to fight. The world would soon learn his name, not as an orphan, but as a legend. The coming storm had a name, and it was Anirudh.</p>
-</div>
-</div>
-<div id="page-4" class="page-content-container">
-    <img src="https://via.placeholder.com/600x400?text=Anirudh+Training" alt="Anirudh practicing with a staff">
+        <p class="dialogue">Your father’s blood flows in you. The blood of the Alchemist King. They will hunt you for it. They will fear you for it. But you must live... you must survive. Grow strong. Be kind. And never, ever forget who you are.</p>
+        <p class="narration">A loud crash of thunder shook the hut, and the flimsy door was thrown open. A figure stood in the doorway, tall and completely hidden by a dark, heavy cloak. No face could be seen, only shadow, but a feeling of cold, deadly intent filled the small room. The woman gasped, her last hope gone. The cloaked figure stepped inside, and her world went black.</p>
+    </div>
     <div class="scene">
-        <div class="narration">
-            The heavy staff hit the tree with a loud WHUMP. Sweat dripped from Anirudh's face. Each swing was filled with a quiet, burning ambition.
-        </div>
-        <div class="character">VILLAGER (O.S.)</div>
-        <div class="dialogue">
-            Hey! Still at it, orphan? You’ll break that tree before you get into that fancy academy!
-        </div>
-        <div class="narration">
-            Anirudh paused, a sharp, dangerous grin flashing across his face. The passing villager, a man with a face as weathered as old leather, flinched back almost imperceptibly. The boy's intensity was unsettling. Anirudh's words did not wound him; they were fuel to a fire that already burned brighter than the sun.
-        </div>
-        <div class="character">ANIRUDH</div>
-        <div class="dialogue">
-            (grinning)
-            Then I’ll break both.
-        </div>
-        <div class="narration">
-            He turned back to the tree, his grin vanishing, replaced by a focus so absolute it seemed to suck the sound from the air around him. The staff resumed its rhythmic assault.
-        </div>
+        <h1>Act 1: The Spark</h1>
+        <h2>The Orphan of Kanjiram</h2>
+        <p class="setting">FIFTEEN YEARS LATER - OUTSIDE KANJIRAM ACADEMY – MORNING</p>
+        <p>Fifteen years of hardship had forged Anirudh into a living weapon. The early morning mist curled around him, a phantom dancing with a blur of motion against the ancient stones of the academy wall. Now fifteen, his body was a testament to a will of iron, lean and powerful. His eyes, dark and intense, held a fire that burned with the heat of a thousand suns. *Faster. Stronger. Better.* The words were a silent mantra, a drumbeat in his soul.</p>
+        <img src="https://via.placeholder.com/600x400?text=Anirudh+Training" alt="Anirudh training with a staff">
+        <p>He wore simple, patched clothes, a declaration that his worth was not measured in silks or gold. He gripped a heavy wooden staff, its surface battered and splintered from countless strikes. He moved with a raw, explosive grace that no formal training could replicate. It was the ferocious, beautiful, and deadly style of a survivor.</p>
+        <p>The heavy staff hit the oak tree with a loud WHUMP. Sweat dripped from his face. Each swing was filled with a quiet, burning ambition. *They look down on me. They see an orphan. A stray. They will see a warrior.*</p>
+        <p class="character">OLD WOMAN (O.S.)</p>
+        <p class="dialogue">Still at it, little sparrow? You'll wear yourself to the bone before the sun is high.</p>
+        <p class="narration">Anirudh paused, his intense focus softening as he saw a familiar, wrinkled face. It was Elina, a woman from the village who sold medicinal herbs. She was the only one who ever spoke to him with anything other than scorn or pity. She held out a small, warm bundle.</p>
+        <p class="character">ELINA</p>
+        <p class="dialogue">Here. You can't forge a sword on an empty stomach. Eat.</p>
+        <p class="narration">Anirudh hesitated, then took the offered flatbread. His pride warred with his hunger. "Thank you, Mother Elina," he mumbled, his eyes on the ground.</p>
+        <p class="character">ELINA</p>
+        <p class="dialogue">(Smiling gently) A strong body needs fuel. A strong spirit needs kindness. Don't you forget that. Now, show this old woman what a warrior's spirit looks like.</p>
+        <p class="narration">As Elina walked away, a group of boys in fine, colorful silks approached. At their lead was Rohan, a student of the academy known for his arrogance. He sneered at the half-eaten bread in Anirudh's hand.</p>
+        <p class="character">ROHAN</p>
+        <p class="dialogue">(Voice dripping with scorn) Look, boys! The stray is being fed scraps. Tell me, orphan, do you really think that's enough to join us? You might as well try to bite the moon.</p>
+        <p class="narration">His friends snickered. Anirudh carefully folded the remaining bread and tucked it into his tunic. He met Rohan's gaze, his own eyes holding a quiet fire that the other boy could not hope to extinguish.</p>
+        <p class="character">ANIRUDH</p>
+        <p class="dialogue">This bread was given with more kindness than you have ever known, Rohan. And it will give me more strength than your silks ever will. The moon is far. But the ground you stand on is close. One day, you'll be looking up at me from there.</p>
+        <p class="narration">His voice was calm, but held an intensity that silenced their laughter. He held Rohan's gaze for a second longer, a silent promise, then turned back to his training as if they were nothing more than buzzing flies, leaving them standing in a stunned, angry silence.</p>
     </div>
 </div>
-<div id="page-5" class="page-content-container">
-<div class="scene">
-    <img src="https://via.placeholder.com/600x400?text=Anirudh+Training" alt="Anirudh training with a staff" class="scene-image">
-    <div class="narration">
-        A group of boys in fine, colorful silks walked by. At their lead was a boy with a sneering face and clothes so pristine they looked ridiculous on the dusty road. He pointed a manicured finger at Anirudh, his friends snickering behind him like a pack of hyenas.
-    </div>
-    <div class="character">BULLY BOY</div>
-    <div class="dialogue">
-        (Voice dripping with scorn)
-        Look who thinks he can join us! You? At Kanjiram Academy? Maybe to clean the stables, orphan!
-    </div>
-    <div class="narration">
-        Anirudh felt the familiar sting, but years of such treatment had forged an iron will within him. He refused to give them the satisfaction of a reaction. He simply met the bully's gaze, his own eyes holding a quiet fire that the other boy could not hope to extinguish.
-    </div>
-    <div class="character">ANIRUDH</div>
-    <div class="dialogue">
-        One day, I’ll stand where the champions do. And you’ll be looking up at me.
-    </div>
-    <div class="narration">
-        His voice was calm, but held an intensity that silenced their laughter. He held the bully's gaze for a second longer, a silent promise, then turned back to his training as if they were nothing more than buzzing flies.
-    </div>
-</div>
-</div>
-<div id="page-6" class="page-content-container">
+<div id="page-6-13-reexpanded" class="page-content-container">
     <div class="scene">
         <div class="setting">KANJIRAM ACADEMY – MAIN GATE – DAY</div>
-        <p>The academy's main gate was a colossal structure of dark stone, carved with symbols of power that seemed to warn away the unworthy. A long line of hopefuls stretched from it, a river of silk, polished leather, and nervous, privileged faces. They were the children of lords and merchants, their hands soft, their expressions arrogant.</p>
-        <p>Among them, Anirudh was a splinter of the real world. His clothes were patched but clean, his hands calloused from work and training. He ignored the whispers and disgusted looks from the other applicants, his gaze fixed on the gate. He belonged here, and he would prove it.</p>
+        <p>The academy's main gate was a colossal structure of dark, volcanic stone, etched with glowing runes of power that seemed to hum with a contained energy. It was designed to awe and intimidate, to separate the worthy from the unworthy. A long line of hopefuls stretched from it, a river of fine silks, polished leather, and nervous, privileged faces. They were the children of lords, wealthy merchants, and decorated generals. Their hands were soft, their expressions a mixture of arrogance and thinly veiled anxiety. Anirudh, in his patched but clean clothes, was a splinter of the real world in their sea of privilege. He ignored the whispers and disgusted looks, his gaze fixed on the gate. *I belong here,* he told himself, the thought a shield against their scorn. *I will prove it.*</p>
+        <p>He reached the front of the line. Before him sat an instructor with a face like carved granite and eyes that missed nothing. The man's gaze swept over Anirudh's worn clothes and calloused hands with a flicker of open disdain. A nameplate on his desk read 'Instructor Kael'.</p>
+        <p class="character">INSTRUCTOR KAEL</p>
+        <p class="dialogue">(In a harsh, bored voice) Name? Lineage?</p>
+        <p class="character">ANIRUDH</p>
+        <p class="dialogue">Anirudh. I have no lineage.</p>
+        <p class="narration">He let the words hang in the air, a simple statement of fact. A ripple of gasps and sneering whispers went through the line behind him. "An orphan." "The gall of it." "Does he really think he has a chance?" Anirudh stood unflinching, his focus entirely on the instructor, a silent challenge in his eyes.</p>
+        <p class="character">INSTRUCTOR KAEL</p>
+        <p class="dialogue">(Scoffs, making a note on his ledger) Anirudh... Just Anirudh. Very well, *Just Anirudh*. We’ll see if you survive the Trials. Don't waste my time. Step forward when called. Next!</p>
     </div>
-</div>
-<div id="page-7" class="page-content-container">
-<div class="scene">
-    <div class="setting">KANJIRAM ACADEMY – MAIN GATE – DAY</div>
-    <p>Anirudh reached the front of the line. Before him sat an instructor with a face like carved stone and eyes that missed nothing. The man's gaze swept over Anirudh's worn clothes with a flicker of disdain.</p>
-    <div class="character">INSTRUCTOR</div>
-    <div class="dialogue">(In a harsh, bored voice) Name?</div>
-    <div class="character">ANIRUDH</div>
-    <div class="dialogue">Anirudh.</div>
-    <div class="action">
-        He did not add "no last name." He let the single name hang in the air, a statement of its own. A ripple of gasps and sneering whispers went through the line. "An orphan." "Worthless." Anirudh stood unflinching, his focus entirely on the instructor, a silent challenge in his eyes.
-    </div>
-    <div class="character">INSTRUCTOR</div>
-    <div class="dialogue">(Looking him up and down) We’ll see if you survive the Trials. Step forward when called.</div>
-</div>
-</div>
-<div id="page-8" class="page-content-container">
-<div class="scene">
-    <p class="narration">The whispers were a cloud of insects at his back, but Anirudh ignored them. Their scorn was a weapon, and he would turn it back on them. Let them see an orphan. Soon, they would see a warrior. He clutched the copper pendant beneath his tunic, its familiar weight a secret promise. He walked towards the waiting area, his shoulders straight, ready for the fire.</p>
-</div>
-</div>
-<div id="page-9-expanded" class="page-content-container">
-    <h2>The Trials of Initiation</h2>
-    <p>EXT. STONE ARENA – TRIAL FIELD – DAY</p>
-    <p>The fifty hopefuls were herded into the Stone Arena, a vast, circular pit carved from the earth, its walls scarred from generations of past trials. The air hummed with nervous energy and the silent judgment of the stern-faced instructors who stood like statues around the perimeter. This was the crucible, and it was about to be lit.</p>
-    <p>An announcer's voice, amplified by a touch of magic, boomed across the arena. "The Trial of Initiation begins! Prove your worth! Only the strongest, the fastest, the most resilient shall pass!"</p>
-</div>
-<div id="page-10-expanded" class="page-content-container">
     <div class="scene">
-        <p>The first challenge was a grueling test of endurance, an obstacle course designed to break the spirit as much as the body. It began with a high wall of rough-hewn stone, followed by a treacherous rope climb over a pit of thick, cloying mud. The privileged youths, who had never known a day of true labor, were the first to falter, their fine silk clothes ruined, their soft hands raw and bleeding.</p>
-        <p>Anirudh moved with a relentless efficiency. He did not have their brute strength, but he had something better: a will of iron and a body that knew how to conserve every ounce of energy. He navigated the course not with speed, but with intelligence, each movement precise and purposeful.</p>
-        <p>He was not the only one excelling. A young man named Rohan, son of the legendary General Kael, moved through the course with a grace that was almost insulting to those struggling around him. His form was perfect, his breathing controlled, his movements a testament to a lifetime of disciplined training. He finished the course first, his pristine white tunic barely smudged with dirt. He stood at the finish line, his arms crossed, his gaze sweeping over the other contestants with a critical eye. He saw Anirudh, who finished not long after him, his patched clothes torn, his face streaked with mud, but his eyes burning with an unyielding fire. Rohan's lip curled in a faint sneer of disapproval. It was not the struggle he disdained, but the lack of form, the crude, unrefined way the orphan had clawed his way through the course.</p>
-    </div>
-</div>
-<div id="page-11-expanded" class="page-content-container">
-    <p>The second trial was one of agility: a treacherous landscape of rising and falling stone pillars over a deep, dark pit. The pillars shifted underfoot, some crumbling at the edges, making the challenge a test of adaptability as much as balance. Here, the formally trained students, including Rohan, tried to apply their rigid techniques. Rohan moved with the precision of a dancer, his steps pre-planned, his balance impeccable. He was a picture of perfect control.</p>
-    <p>Anirudh, however, moved with a feral instinct. His style was born from a life of dodging angry merchants and leaping across the rooftops of the city's slums. He didn't think; he reacted, his body a blur of motion, his worn boots finding purchase on surfaces that should have been impossible to stand on. He moved like a creature of the wild, unpredictable and unstoppable.</p>
-</div>
-<div id="page-12-expanded" class="page-content-container">
-    <div class="scene">
-        <p>The third test was of power. The goal: to move a massive stone boulder. The largest youths, full of pride, attempted the heaviest boulders and failed, their muscles giving out in shuddering spasms. Rohan, ever the strategist, chose a large but manageable stone. With a great shout, he channeled his inner energy, his muscles bulging, and heaved the stone a respectable distance, earning a round of applause from the instructors.</p>
-        <p>Anirudh, ever the outsider, studied the stones and the terrain. He chose a smaller boulder, earning a few sneers from the crowd. But then he did something no one expected. He picked up his battered wooden staff, wedged it into a crevice beneath the boulder, and used the slight incline of the ground to his advantage. With a perfectly timed heave, using the staff as a lever, he sent the boulder rolling farther than anyone else's, including Rohan's.</p>
-        <p>A stunned silence fell over the arena, followed by a ripple of grudging admiration. Rohan's face was a mask of cold fury. The orphan had not just succeeded; he had cheated, in his eyes. He had used a tool, a trick, instead of pure, honest strength. He saw Anirudh not as a clever competitor, but as a charlatan, a stain on the honor of the trials. The rivalry, in that moment, was born.</p>
-    </div>
-</div>
-<div id="page-13-expanded" class="page-content-container">
-    <div class="scene">
-        <p>From a high platform, two instructors watched. One was the stern-faced man from the gate. The other, a man with a sharp beard and intelligent eyes, was Master Elara. "The boy Rohan is the very picture of a Kanjiram student," the stern instructor said with a nod of approval. "Perfect form, perfect discipline."</p>
-        <p>Master Elara's eyes, however, were on Anirudh. "Rohan is a finely crafted sword," he murmured, a hint of fascination in his voice. "But Anirudh... he is the unquenchable fire that forges the steel. There is a power in him that cannot be taught."</p>
+        <h2>The Trials of Initiation</h2>
+        <p class="setting">EXT. STONE ARENA – TRIAL FIELD – DAY</p>
+        <p>The fifty hopefuls were herded into the Stone Arena, a vast, circular pit carved from the earth, its walls scarred from generations of past trials. The air hummed with nervous energy and the silent judgment of the stern-faced instructors who stood like statues around the perimeter. From a high platform, two instructors watched the proceedings. One was the stern-faced Instructor Kael. The other, a man with a sharp beard and intelligent, twinkling eyes, was Master Elara, one of the academy's most respected teachers.</p>
+        <p>An announcer's voice, amplified by a touch of magic, boomed across the arena. "The Trial of Initiation begins! Prove your worth! Only the strongest, the fastest, the most resilient shall pass! The first trial tests your endurance!"</p>
+        <p>The first challenge was a grueling obstacle course designed to break the spirit as much as the body. It began with a high wall of rough-hewn stone, followed by a treacherous rope climb over a pit of thick, cloying mud. The privileged youths, who had never known a day of true labor, were the first to falter, their fine silks ruined, their soft hands raw and bleeding. Anirudh moved with a relentless efficiency, his will a burning fire. He navigated the course not with brute speed, but with a street-smart intelligence, each movement precise and purposeful, conserving every ounce of energy.</p>
+        <p>He was not the only one excelling. Rohan, son of the legendary General Kael, moved with an insulting, effortless grace. His form was perfect, his movements a testament to a lifetime of disciplined training. He finished first, his pristine white tunic barely smudged. He stood at the finish line, arms crossed, his gaze sweeping over the other contestants with a critical eye. He saw Anirudh finish not long after, his patched clothes torn, his face streaked with mud, but his eyes burning with an unyielding fire. Rohan's lip curled in a faint sneer. *Crude. Unrefined. He fights like an animal,* Rohan thought, disgusted by the orphan's lack of form.</p>
+        <p>The second trial was one of agility: a treacherous landscape of rising and falling stone pillars over a deep, dark pit. The pillars shifted underfoot, some crumbling at the edges. Rohan moved with the precision of a dancer, his steps pre-planned, his balance impeccable. Anirudh, however, moved with a feral instinct born from a life of dodging angry merchants and leaping across the rooftops of the city's slums. He didn't think; he reacted, his body a blur of motion, his worn boots finding purchase on surfaces that should have been impossible to stand on.</p>
+        <p>"The boy Rohan is the very picture of a Kanjiram student," Instructor Kael said with a nod of approval. "Perfect form, perfect discipline. He is a finely crafted sword."</p>
+        <p>Master Elara's eyes, however, were on Anirudh. "A sword is useless if it shatters against the rock," he murmured, a hint of fascination in his voice. "Look at the orphan, Kael. He is not a sword. He is the unquenchable fire that forges the steel. There is a power in him that cannot be taught. It is... interesting."</p>
+        <p>The third test was of power: moving a massive stone boulder. The largest youths, full of pride, attempted the heaviest boulders and failed, their muscles giving out in shuddering spasms. Rohan, ever the strategist, chose a large but manageable stone. With a great shout, he channeled his inner energy, his muscles bulging, and heaved the stone a respectable distance, earning a round of applause from the instructors.</p>
+        <p>Anirudh, ever the outsider, studied the stones and the terrain. He chose a smaller boulder, earning sneers from the crowd. But then he did something no one expected. He picked up his battered wooden staff, wedged it into a crevice beneath the boulder, and used the slight incline of the ground to his advantage. With a perfectly timed heave, using the staff as a lever, he sent the boulder rolling farther than anyone else's, including Rohan's.</p>
+        <p>A stunned silence fell over the arena. Rohan's face was a mask of cold fury. "He cheated!" Rohan yelled, pointing at Anirudh. "He used a tool! That is not the Kanjiram way! Strength must be pure!"</p>
+        <p>Instructor Kael nodded grimly. "The boy has a point, Elara. The rules imply a test of pure, physical strength."</p>
+        <p>Master Elara smiled faintly. "Do the rules *state* that, Kael? Or do you merely *infer* it? The trial is to move the stone. The boy was given a challenge, and he used the tools available to him—his mind and his staff—to overcome it. That is not cheating. That is intelligence. The kind of intelligence that wins wars, not just tournament bouts." The grudging admiration from the crowd grew, and Rohan's hatred for the orphan solidified into a cold, hard diamond in his heart.</p>
     </div>
 </div>
 <div id="page-14" class="page-content-container"><p class="narration">That night, unable to rest, Anirudh slipped into the academy's grand library. He was not looking for textbooks, but for answers. He searched the forbidden sections, his fingers tracing the spines of ancient, dust-covered tomes, seeking any clue about the strange, swirling symbol on the pendant he wore, his only link to a past he could not remember.</p></div>
-<div id="page-15" class="page-content-container">
-<div class="scene">
-    <p class="narration">Days of brutal trials passed. The field of fifty hopefuls had been whittled down to a handful of exhausted, but determined, survivors. A great voice echoed across the arena.</p>
-    <p class="character">ANNOUNCER (V.O.)</p>
-    <p class="dialogue">"The final trial is at hand! Only ten shall be granted entry into the esteemed Kanjiram Academy!"</p>
-    <p class="narration">The remaining students looked at each other, their camaraderie replaced by fierce rivalry. Anirudh’s expression, however, remained unchanged. His gaze was locked forward, his will absolute. He only needed one spot.</p>
-</div>
-</div>
-<div id="page-16" class="page-content-container">
+<div id="page-15-23-reexpanded" class="page-content-container">
     <div class="scene">
-        <p class="narration">The final challenge was combat. A single figure emerged from the shadows of the arena gate. They were tall, cloaked, and their face was hidden by a featureless, black mask that seemed to drink the light. An aura of immense power and deadly skill radiated from them. It was a masked instructor, a master of the Kanjiram arts.</p>
-        <p class="narration">The other students hesitated, their courage failing them. But Anirudh, though weary, felt a surge of adrenaline. This was it. The ultimate test. He stepped forward without a single word, his worn boots crunching on the arena sand, and stood alone before the terrifying figure.</p>
-    </div>
-</div>
-<div id="page-17" class="page-content-container">
-    <p>The masked instructor’s head tilted slightly. The voice that came from behind the mask was low and laced with contempt.</p>
-    <p>"You have lasted this long, orphan," the instructor said. "A surprise. But your journey ends here."</p>
-    <p>The insult, meant to unbalance him, had the opposite effect. It centered him. Anirudh's jaw tightened, and the fire in his eyes burned hotter.</p>
-</div>
-<div id="page-18" class="page-content-container">
-    <div class="scene">
-        <p>For Anirudh, the word "orphan" was not an insult. It was a badge of honor. It was a testament to his unbreakable will to survive in a world that had given him nothing.</p>
-        <p>He straightened his shoulders, his voice clear and steady, ringing with a power that surprised even himself.</p>
+        <p class="narration">Days of brutal trials passed. The field of fifty hopefuls had been whittled down to a handful of exhausted, but determined, survivors. A great voice echoed across the arena.</p>
+        <p class="character">ANNOUNCER (V.O.)</p>
+        <p class="dialogue">"The final trial is at hand! A test of pure combat! Only ten shall be granted entry into the esteemed Kanjiram Academy! Your opponent will be one of our own instructors. You are not expected to win. You are expected to endure."</p>
+        <p class="narration">The remaining students looked at each other, their camaraderie replaced by fierce rivalry. Anirudh’s expression, however, remained unchanged. His gaze was locked forward, his will absolute. He only needed one spot.</p>
+        <p class="narration">A single figure emerged from the shadows of the arena gate. They were tall, cloaked, and their face was hidden by a featureless, black mask that seemed to drink the light. An aura of immense power and deadly skill radiated from them. It was a masked instructor, a master of the Kanjiram arts.</p>
+        <p class="narration">The other students hesitated, their courage failing them. Rohan, despite his bravado, took an involuntary step back. But Anirudh, though weary, felt a surge of adrenaline. This was it. The ultimate test. He stepped forward without a single word, his worn boots crunching on the arena sand, and stood alone before the terrifying figure.</p>
+        <p>The masked instructor’s head tilted slightly. The voice that came from behind the mask was low and laced with contempt. "You have lasted this long, orphan," the instructor said. "A surprise. But your journey ends here. You have no place in this academy."</p>
+        <p>The insult, meant to unbalance him, had the opposite effect. It centered him. Anirudh's jaw tightened, and the fire in his eyes burned hotter. For Anirudh, the word "orphan" was not an insult. It was a badge of honor.</p>
         <p><span class="character">ANIRUDH</span></p>
-        <p>"Orphans learn to fight harder than anyone. We have everything to prove."</p>
-        <p>He was not just fighting for a place in an academy. He was fighting for his past, his future, and his very identity. He would not be broken.</p>
-    </div>
-</div>
-<div id="page-19" class="page-content-container">
-    <div class="scene">
-        <p>The instructor attacked with blinding speed and precision. It was like fighting a whirlwind. Anirudh was instantly on the defensive, his staff a blur as he parried a furious storm of blows. He was outmatched in skill and technique, but not in spirit.</p>
-        <p>He grit his teeth, his mind racing. He could not win a conventional fight. He had to be unconventional. He had to be unpredictable. He had to be the survivor he had always been.</p>
-    </div>
-</div>
-<div id="page-20" class="page-content-container">
-    <div class="page-content">
-        <p>Anirudh abandoned the formal stances he had tried to learn. He began to move in a way that was uniquely his own—a messy, chaotic, and brilliant dance of survival. He ducked under a sweeping strike that should have taken his head off and, in the same motion, swept his leg out in a low, unexpected attack.</p>
-        <p>It was not a powerful move, but it was perfectly timed. It caught the instructor's ankle, breaking their perfect stance. The master stumbled. A wave of shock rippled through the crowd. The untouchable instructor had been hit.</p>
-    </div>
-</div>
-<div id="page-21" class="page-content-container">
-    <div class="page-content">
-        <p>The instructor, a master of formal combat, was completely unprepared for Anirudh's wild, street-honed style. The stumble was more than a physical misstep; it was a crack in their aura of invincibility. For the first time, the crowd saw not an orphan, but a contender. Whispers of awe replaced the earlier sneers.</p>
-    </div>
-</div>
-<div id="page-22" class="page-content-container">
-    <p>The instructor, now furious, attacked with even greater intensity. But the dynamic of the fight had shifted. Anirudh had proven he was not some street rat to be easily crushed. He was a force to be reckoned with. The impossible had just happened, and everyone had seen it.</p>
-</div>
-<div id="page-23" class="page-content-container">
-    <div class="scene">
-        <p>The instructor pressed their attack, but Anirudh was no longer just trying to win. He was trying to endure. He knew he could not defeat the master, but he could refuse to be defeated. Every block, every dodge, was a declaration of his will.</p>
-        <p>The seconds stretched into an eternity. The arena was silent, the crowd watching with bated breath as the orphan boy refused to fall. Then, the final bell rang, its clear note echoing through the arena.</p>
-        <p>The fight was over. Anirudh stood, bruised, battered, and trembling with exhaustion, but he was still standing. He had not won the fight, but he had won something far more important: respect.</p>
+        <p>"Orphans learn to fight harder than anyone," he said, his voice clear and steady. "We have everything to prove. And I will prove that I belong."</p>
+        <p class="narration">The instructor attacked with blinding speed and precision. It was like fighting a whirlwind. Anirudh was instantly on the defensive, his staff a blur as he parried a furious storm of blows. Each block sent a jarring shock up his arms. He was outmatched in skill and technique, but not in spirit. He grit his teeth, his mind racing. *I can't win a conventional fight. He's too fast, too strong. I have to be unpredictable. I have to be the survivor I have always been.*</p>
+        <p class="narration">Anirudh abandoned the formal stances he had tried to learn. He began to move in a way that was uniquely his own—a messy, chaotic, and brilliant dance of survival. He ducked under a sweeping strike that should have taken his head off and, in the same motion, swept his leg out in a low, unexpected attack. It was not a powerful move, but it was perfectly timed. It caught the instructor's ankle, breaking their perfect stance. The master stumbled. A wave of shock rippled through the crowd. The untouchable instructor had been hit.</p>
+        <p class="narration">The instructor, a master of formal combat, was completely unprepared for Anirudh's wild, street-honed style. The stumble was more than a physical misstep; it was a crack in their aura of invincibility. For the first time, the crowd saw not an orphan, but a contender. Whispers of awe replaced the earlier sneers. Even Rohan watched with a new, grudging respect in his eyes.</p>
+        <p class="narration">The instructor, now furious, attacked with even greater intensity. But the dynamic of the fight had shifted. Anirudh had proven he was not some street rat to be easily crushed. He was no longer just trying to win. He was trying to endure. He knew he could not defeat the master, but he could refuse to be defeated. Every block, every dodge, was a declaration of his will.</p>
+        <p class="narration">The seconds stretched into an eternity. The arena was silent, the crowd watching with bated breath as the orphan boy refused to fall. Then, the final bell rang, its clear note echoing through the arena.</p>
+        <p class="narration">The fight was over. Anirudh stood, bruised, battered, and trembling with exhaustion, but he was still standing. He had not won the fight, but he had won something far more important: respect. He had proven he belonged.</p>
     </div>
 </div>
 <div id="page-24" class="page-content-container">
@@ -238,533 +135,453 @@
     <p>His fingers traced the spines of the ancient books until he found it: a heavy, leather-bound tome with a symbol on its cover that matched the one on his pendant. With trembling hands, he opened it. The book spoke of the Alchemist King, of a powerful lineage, and of monstrous creatures called Wildblood Beasts that were drawn to the king's power. A chill went down his spine. The pendant wasn't just a memento. It was a key. And it made him a target.</p>
 </div>
 <!-- ACT 2: THE RIVALRY -->
-<div id="page-34" class="page-content-container">
+<div id="page-34-40-reexpanded" class="page-content-container">
     <h1>Act 2: The Rivalry</h1>
     <h2>Chapter 1: A New Lead</h2>
-    <p>The words in the ancient tome echoed in Anirudh's mind: "Wildblood Beasts, drawn to the king's power." The pendant around his neck suddenly felt heavier, a beacon in the darkness. He knew he couldn't stay at Kanjiram. The academy was a place of rigid rules and secrets, and he needed answers, not just training. The book mentioned a rival institution, the Vidyut Academy, known for its expertise in ancient lore and magical artifacts. It was a long shot, but it was the only lead he had.</p>
-</div>
-<div id="page-35" class="page-content-container">
+    <p>The words in the ancient tome echoed in Anirudh's mind: "Wildblood Beasts, drawn to the king's power." The pendant around his neck suddenly felt heavier, a beacon in the darkness. He knew he couldn't stay at Kanjiram. The academy was a place of rigid rules and secrets, and he needed answers, not just training. The book mentioned a rival institution, the Vidyut Academy, known for its expertise in ancient lore and magical artifacts. It was a long shot, but it was the only lead he had. He had to go. He had to know.</p>
+
     <h2>Chapter 2: The Journey</h2>
-    <p>Leaving Kanjiram was surprisingly easy. Anirudh was an outcast, a ghost in the hallowed halls. He packed his few belongings, his battered staff, and the heavy book, and slipped out under the cover of darkness. The journey to Vidyut was long and arduous, a test of the survival skills he had honed his entire life. He traveled through dense forests and across treacherous mountains, the pendant a constant, warm presence against his skin.</p>
-</div>
-<div id="page-36" class="page-content-container">
+    <p>Leaving Kanjiram was surprisingly easy. Anirudh was an outcast, a ghost in the hallowed halls. He packed his few belongings: his battered staff, the heavy book, and a small pouch with the last of his coins. He slipped out under the cover of darkness, a silent promise to himself to return one day, not as a student, but as a master. The journey to Vidyut was long and arduous, a test of the survival skills he had honed his entire life. He traveled through dense forests where the trees whispered ancient secrets, and across treacherous mountains where the wind howled like a banshee. He hunted for his food, slept in caves, and washed in ice-cold streams. The pendant was a constant, warm presence against his skin, a reminder of his purpose.</p>
+
     <h2>Chapter 3: The Gates of Vidyut</h2>
-    <p>The Vidyut Academy was nothing like Kanjiram. Where Kanjiram was stone and discipline, Vidyut was a vibrant, chaotic hub of magical energy. The air crackled with power, and the students were a diverse mix of scholars, inventors, and warriors. The academy was built around a massive, crystalline structure that pulsed with a soft, blue light. Anirudh, clad in his worn traveler's clothes, felt even more out of place than he had at Kanjiram.</p>
+    <p>After weeks of travel, he finally saw it. The Vidyut Academy was nothing like Kanjiram. Where Kanjiram was stone and discipline, Vidyut was a vibrant, chaotic hub of magical energy. The academy was built around a massive, crystalline structure that pulsed with a soft, blue light, casting an ethereal glow over the entire campus. The air crackled with power, and the students were a diverse mix of scholars, inventors, and warriors, each buzzing with their own projects and experiments. Anirudh, clad in his worn traveler's clothes, felt even more out of place than he had at Kanjiram. He was a simple warrior in a world of mages.</p>
     <img src="https://via.placeholder.com/600x400?text=Vidyut+Academy" alt="Vidyut Academy">
-</div>
-<div id="page-37" class="page-content-container">
+
     <h2>Chapter 4: A Hostile Welcome</h2>
-    <p>Anirudh's arrival did not go unnoticed. A group of Vidyut students, led by a tall, arrogant youth with lightning-fast reflexes, blocked his path. "Another stray from Kanjiram?" the leader sneered. "Lost your way, have you? This is a place of knowledge, not brute force."</p>
-</div>
-<div id="page-38" class="page-content-container">
+    <p>Anirudh's arrival did not go unnoticed. A group of Vidyut students, their robes crackling with latent magical energy, blocked his path. At their lead was a tall, arrogant youth with lightning-fast reflexes and a sneer that reminded Anirudh of Rohan. "Another stray from Kanjiram?" the leader sneered, his eyes raking over Anirudh's simple staff and worn clothes. "Lost your way, have you? This is a place of knowledge, of magic, not brute force. We have no need for your kind here."</p>
+
     <h2>Chapter 5: The First Clash</h2>
-    <p>The leader introduced himself as Arjun. He was Vidyut's top student, a master of elemental magic. He saw Anirudh's staff and the raw power in his stance and dismissed him as an uncultured brawler. "You want to enter our halls?" Arjun challenged, his hands crackling with electricity. "You'll have to get through me first."</p>
-</div>
-<div id="page-39" class="page-content-container">
+    <p>The leader introduced himself as Arjun. He was Vidyut's top student, a master of elemental magic. He saw Anirudh's staff and the raw power in his stance and dismissed him as an uncultured brawler. "You want to enter our halls?" Arjun challenged, his hands crackling with electricity. "You'll have to get through me first. Let's see what the 'warriors' of Kanjiram are made of."</p>
+
     <h2>Chapter 6: A Different Kind of Power</h2>
-    <p>Anirudh didn't want to fight, but he wouldn't back down. The clash was brief but intense. Arjun's magic was fast and flashy, a storm of lightning and wind. Anirudh's style was grounded and powerful, each block and parry a testament to his unyielding will. He didn't win, but he held his ground, much to Arjun's surprise and fury.</p>
-</div>
-<div id="page-40" class="page-content-container">
+    <p>Anirudh didn't want to fight, but he wouldn't back down. The clash was brief but intense. Arjun's magic was a dazzling and deadly storm of lightning and wind. Anirudh's style was grounded and powerful, each block and parry a testament to his unyielding will. He was a rock against which Arjun's storm crashed. He didn't win, but he held his ground, much to Arjun's surprise and fury. The other Vidyut students watched in stunned silence, their arrogant smirks replaced with expressions of disbelief.</p>
+
     <h2>Chapter 7: An Unexpected Ally</h2>
-    <p>A Vidyut instructor, a wise old woman named Master Leela, intervened. She saw something in Anirudh's eyes, a fire that reminded her of the ancient kings. She granted him temporary access to the academy's library, much to Arjun's disgust. "There is more to power than flashy tricks, Arjun," she said, her eyes twinkling. "You would do well to remember that."</p>
+    <p>A Vidyut instructor, a wise old woman with eyes that seemed to see into his very soul, intervened. It was Master Leela, the head of the Department of Ancient Lore. She had been watching from a distance, intrigued by the boy who could stand against Arjun's elemental fury. She saw something in Anirudh's eyes, a fire that reminded her of the ancient kings. "That is enough, Arjun," she said, her voice calm but firm. Arjun reluctantly powered down, his glare still fixed on Anirudh. Master Leela turned to Anirudh. "You fight with the heart of a lion, young one. But you are unrefined. I will grant you temporary access to our library. Perhaps you will find what you are looking for there." Arjun scoffed in disgust. "There is more to power than flashy tricks, Arjun," she said, her eyes twinkling. "You would do well to remember that."</p>
 </div>
-<div id="page-41" class="page-content-container">
+<div id="page-41-45-reexpanded" class="page-content-container">
     <h2>Chapter 8: The Library of Whispers</h2>
-    <p>Vidyut's library was even larger than Kanjiram's, a labyrinth of towering shelves filled with scrolls and tomes on every imaginable subject. Anirudh spent days poring over ancient texts, searching for any mention of the Alchemist King or the Crimson Pendant. He found whispers, hints of a forgotten history, but nothing concrete.</p>
-</div>
-<div id="page-42" class="page-content-container">
+    <p>Vidyut's library was even larger than Kanjiram's, a labyrinth of towering shelves that seemed to touch the cavernous, crystal-lit ceiling. The air hummed with the quiet energy of a million sleeping stories. Anirudh, used to the stern silence of the Kanjiram library, was overwhelmed by the sheer scale of it. He spent days poring over ancient texts, searching for any mention of the Alchemist King or the Crimson Pendant. He found whispers, hints of a forgotten history, but nothing concrete. The texts spoke of a line of kings who could command the very elements, but their history was fragmented, as if deliberately erased.</p>
+    <p>He was about to give up for the day when a wizened old man with a long, white beard and spectacles perched on his nose appeared from behind a towering stack of books. "Lost, young Kanjiram?" the old man asked, his voice a dry rustle of old parchment. "Or perhaps you are looking for something that does not wish to be found?"</p>
+    <p>"I... I'm looking for information about the Alchemist King," Anirudh said, surprised.</p>
+    <p>The old man's eyes twinkled. "Ah, the ghost king. A dangerous topic. Most of the records were destroyed during the Great Purge. But not all. I am Master Vayu, the keeper of this library. If you are truly seeking knowledge, and not just power, you may find what you seek. But be warned, some doors are best left unopened." He pointed a long, bony finger towards a dusty, forgotten corner of the library. "Start there," he said, before disappearing back into the maze of shelves.</p>
+
     <h2>Chapter 9: The Tournament Announcement</h2>
-    <p>The academy was buzzing with excitement. The annual Inter-Academy Tournament was announced, a competition of skill and power between Kanjiram and Vidyut. The grand prize was a rare and powerful artifact from the Vidyut vaults. Anirudh saw it as an opportunity. If he could win, he might gain access to the information he so desperately needed.</p>
-</div>
-<div id="page-43" class="page-content-container">
+    <p>A few days later, the academy was buzzing with excitement. The annual Inter-Academy Tournament was announced, a competition of skill and power between Kanjiram and Vidyut. The grand prize was a rare and powerful artifact from the Vidyut vaults: the Sunstone, an object said to amplify the wielder's innate power. Anirudh saw it as an opportunity. If he could win, he might gain access to the restricted sections of the library, where the truth about his father might be hidden.</p>
+
     <h2>Chapter 10: A Rival's Scorn</h2>
-    <p>Arjun, of course, was Vidyut's chosen champion. He saw Anirudh's interest in the tournament as an insult. "You think you can compete with me?" he scoffed. "You're a relic, an echo of a forgotten age. This is an era of magic, not brute strength." The rivalry between them intensified, a clash of philosophies and power.</p>
-</div>
-<div id="page-44" class="page-content-container">
+    <p>Arjun, of course, was Vidyut's chosen champion. He saw Anirudh's interest in the tournament as a personal insult. He confronted Anirudh in the library, his voice a low, angry hiss. "You think you can compete with me? You're a relic, an echo of a forgotten age. This is an era of magic, not brute strength. Go back to your dusty corner and play with your history books, orphan. The tournament is for real warriors."</p>
+    <p>"A real warrior fights for something more than just pride," Anirudh retorted, not looking up from the ancient text he was studying. "You should try it sometime."</p>
+    <p>Arjun, furious at being dismissed so easily, stormed away, leaving Anirudh to his research. The rivalry between them intensified, a clash of philosophies and power.</p>
+
     <h2>Chapter 11: Training Montage</h2>
-    <p>Anirudh began to train with a new ferocity. He knew he was at a disadvantage. He had no formal training in magic. But he had his staff, his will, and the raw, untamed power that flowed from the pendant. He pushed himself to the brink, his body aching, his spirit burning.</p>
-</div>
-<div id="page-45" class="page-content-container">
+    <p>Anirudh began to train with a new ferocity. He knew he was at a disadvantage. He had no formal training in magic. But he had his staff, his will, and the raw, untamed power that flowed from the pendant. He pushed himself to the brink, his body aching, his spirit burning. He practiced in the dead of night, in the deserted training grounds, his movements a blur of controlled fury. He was not just training his body; he was training his mind, trying to understand the connection between his physical strength and the strange power of the pendant.</p>
+
     <h2>Chapter 12: A Glimmer of Respect</h2>
-    <p>Arjun, despite his arrogance, couldn't help but notice Anirudh's dedication. He saw the orphan training day and night, his determination unwavering. He wouldn't admit it, but a small part of him was impressed. He started to see Anirudh not as a brawler, but as a warrior.</p>
+    <p>Arjun, despite his arrogance, couldn't help but notice Anirudh's dedication. He saw the orphan training day and night, his determination unwavering. He wouldn't admit it, but a small part of him was impressed. He started to see Anirudh not as a brawler, but as a warrior with a purpose. One evening, from the shadows of the training grounds, he watched Anirudh practice, a flicker of something that might have been respect in his eyes.</p>
 </div>
-<div id="page-46" class="page-content-container">
-    <h2>Chapter 13: The First Trial</h2>
-    <p>To qualify for the tournament, Anirudh had to pass a series of trials. The first was a test of intellect, a complex magical puzzle. Anirudh, using the knowledge he had gleaned from the library, solved it in a way no one expected, using logic and observation instead of raw magical power.</p>
-</div>
-<div id="page-47" class="page-content-container">
-    <h2>Chapter 14: The Second Trial</h2>
-    <p>The second trial was a test of stealth. Anirudh had to navigate a booby-trapped maze without being detected. His years of living on the streets, of being unseen and unheard, served him well. He moved through the maze like a phantom, his senses honed to a razor's edge.</p>
-</div>
-<div id="page-48" class="page-content-container">
-    <h2>Chapter 15: The Third Trial</h2>
-    <p>The final trial was a duel. Anirudh was pitted against one of Vidyut's top magical duelists. The fight was intense, a whirlwind of fire and steel. Anirudh, using his staff and his wits, managed to win, earning a spot in the tournament. He was no longer just the orphan from Kanjiram. He was a contender.</p>
-</div>
-<div id="page-49" class="page-content-container">
+<div id="page-46-53-reexpanded" class="page-content-container">
+    <h2>Chapter 13: The Trials of Vidyut</h2>
+    <p>To qualify for the tournament, Anirudh had to pass a series of trials designed to test the unique skills valued at Vidyut. The first was a test of intellect: a complex magical puzzle box that shifted and changed in response to the user's magical energy. The other contestants, all mages, tried to force it open with raw power. Anirudh, using the knowledge he had gleaned from the library and the guidance of Master Vayu, solved it in a way no one expected. He didn't use magic. He used logic and observation, finding the subtle seams and patterns in the box's design, treating it not as a magical lock, but as a complex mechanical one. He opened it in record time, much to the astonishment of the examiners.</p>
+
+    <h2>Chapter 14: The Maze of Whispers</h2>
+    <p>The second trial was a test of stealth and mental fortitude. Anirudh had to navigate a booby-trapped maze while being bombarded with magical illusions and whispers of doubt. His years of living on the streets, of being unseen and unheard, served him well. He moved through the maze like a phantom, his senses honed to a razor's edge. The whispers, designed to prey on his insecurities, were a familiar enemy. He had faced the scorn of others his entire life. He pushed through the illusions, his will a shield against the magical assault.</p>
+
+    <h2>Chapter 15: The Duelist's Challenge</h2>
+    <p>The final trial was a duel. Anirudh was pitted against one of Vidyut's top magical duelists, a young woman named Lyra who could weave illusions of fire and ice. The fight was intense, a whirlwind of fire and steel. Lyra's illusions were almost perfect, but Anirudh had learned to trust his senses, to feel the shift in the air that betrayed the location of his real opponent. He used his staff and his wits, his movements unpredictable and chaotic, and managed to win, earning a spot in the tournament. He was no longer just the orphan from Kanjiram. He was a contender. And he had earned a grudging respect from the students of Vidyut.</p>
+
     <h2>Chapter 16: A New Conspiracy</h2>
-    <p>During his research, Anirudh stumbled upon a dark secret. He found evidence of a hidden faction within Vidyut, a group obsessed with forbidden magic and the power of the Wildblood Beasts. He realized the tournament might be more than just a competition. It could be a trap.</p>
-</div>
-<div id="page-50" class="page-content-container">
+    <p>During his research in the dusty corner of the library that Master Vayu had pointed him to, Anirudh stumbled upon a dark secret. He found a hidden compartment in an ancient tome, and inside, a series of letters. They spoke of a hidden faction within Vidyut, a group obsessed with forbidden magic and the power of the Wildblood Beasts. The letters were signed with the symbol of a coiled serpent. He realized the tournament might be more than just a competition. It could be a trap to lure out those with the blood of the ancient kings.</p>
+
     <h2>Chapter 17: An Unlikely Alliance</h2>
-    <p>Anirudh knew he couldn't face this threat alone. He needed help. He swallowed his pride and approached Arjun, showing him the evidence he had found. Arjun was skeptical at first, but the proof was undeniable. A dark shadow was looming over their world, and they were the only ones who saw it.</p>
-</div>
-<div id="page-51" class="page-content-container">
+    <p>Anirudh knew he couldn't face this threat alone. He needed help. He swallowed his pride and approached Arjun, showing him the letters he had found. Arjun was skeptical at first, his pride still smarting from their earlier confrontation. "This is probably just some student prank," he scoffed.</p>
+    <p>"Does this look like a prank?" Anirudh asked, pointing to the serpent symbol. "I've seen this before. In the book that led me here. This is real, Arjun. And it's dangerous."</p>
+    <p>Arjun studied the letters, his expression slowly changing from scorn to concern. The proof was undeniable. A dark shadow was looming over their world, and they were the only ones who saw it. "What do you propose we do?" Arjun asked, his voice now serious.</p>
+
     <h2>Chapter 18: The Scroll of Shadows</h2>
-    <p>The evidence pointed to a legendary artifact, the Scroll of Shadows, which was said to contain the secrets of controlling the Wildblood Beasts. It was hidden somewhere within the academy, in a place known as the Sunken Library. They knew they had to find it before the conspirators did.</p>
-</div>
-<div id="page-52" class="page-content-container">
+    <p>"The letters speak of an artifact," Anirudh explained. "The Scroll of Shadows. It is said to contain the secrets of controlling the Wildblood Beasts. They are planning to use the tournament to acquire it. We have to find it first."</p>
+
     <h2>Chapter 19: The Sunken Library</h2>
-    <p>Getting to the Sunken Library would be a perilous journey. It was a place of myth and legend, guarded by ancient traps and magical creatures. But they had no choice. The fate of both academies, and perhaps the world, depended on it. Anirudh and Arjun, the rivals, were now reluctant allies.</p>
-</div>
-<div id="page-53" class="page-content-container">
+    <p>Arjun's eyes widened. "The Scroll of Shadows is a myth. A legend. It is said to be hidden in the Sunken Library, a place that no one has entered for centuries."</p>
+    <p>"Then we will be the first," Anirudh said, his voice firm. "The fate of both our academies, and perhaps the world, depends on it."</p>
+    <p>Arjun looked at Anirudh, a new respect in his eyes. The orphan from Kanjiram was more than just a brawler. He was a warrior with a purpose. "Very well," Arjun said with a nod. "It seems we are allies. For now."</p>
+
     <h2>Chapter 20: The Descent</h2>
-    <p>Under the cover of a moonless night, Anirudh and Arjun made their way to the hidden entrance of the Sunken Library. The air grew cold and damp as they descended into the darkness, the weight of their mission heavy on their shoulders. The rivalry was forgotten, replaced by a shared sense of purpose and a growing dread of what they might find below.</p>
+    <p>Under the cover of a moonless night, Anirudh and Arjun made their way to the hidden entrance of the Sunken Library, a secret passage hidden behind a waterfall. The air grew cold and damp as they descended into the darkness, the weight of their mission heavy on their shoulders. The rivalry was forgotten, replaced by a shared sense of purpose and a growing dread of what they might find below.</p>
 </div>
 <!-- ACT 3: THE SCROLL HUNT -->
-<div id="page-54" class="page-content-container">
+<div id="page-54-60-reexpanded" class="page-content-container">
     <h1>Act 3: The Scroll Hunt</h1>
     <h2>Chapter 21: The Guardian</h2>
-    <p>The entrance to the Sunken Library was guarded by a massive stone golem, its eyes glowing with a malevolent red light. It was an ancient guardian, programmed to destroy any intruders. "So much for a quiet entry," Arjun muttered, his hands already crackling with lightning.</p>
-</div>
-<div id="page-55" class="page-content-container">
+    <p>The entrance to the Sunken Library was guarded by a massive stone golem, its eyes glowing with a malevolent red light. It was an ancient guardian, activated by their presence. "So much for a quiet entry," Arjun muttered, his hands already crackling with lightning. "This is a guardian of the old kingdom. It's not just strong, it's smart."</p>
+
     <h2>Chapter 22: A Test of Teamwork</h2>
-    <p>The fight was a brutal test of their newfound alliance. Arjun's magic was powerful but ineffective against the golem's stone hide. Anirudh's staff, however, could find the cracks in its armor. They had to work together, Arjun distracting the golem while Anirudh targeted its weak points. It was a clumsy, uncoordinated dance, but it worked.</p>
-</div>
-<div id="page-56" class="page-content-container">
+    <p>The fight was a brutal test of their newfound alliance. Arjun's magic, powerful as it was, was ineffective against the golem's stone hide. Anirudh's staff, however, could find the cracks in its armor. They had to work together. "Distract it!" Anirudh yelled, dodging a massive stone fist. "I have an idea!"</p>
+    <p>Arjun unleashed a blinding flash of light, momentarily stunning the golem. In that instant, Anirudh used his staff to pry a glowing rune from the golem's chest. The golem shuddered, its movements becoming slower, more erratic. "It's powered by these runes!" Anirudh shouted. "Help me get the rest of them!" It was a clumsy, uncoordinated dance, but it worked. With the final rune removed, the golem crumbled into a pile of dust and rock.</p>
+
     <h2>Chapter 23: The Library's Depths</h2>
-    <p>With the golem defeated, they entered the library proper. It was a breathtaking sight, a massive cavern filled with towering shelves of water-logged books and glowing crystals. The air was thick with the scent of wet paper and ancient magic. "This place is a treasure trove," Arjun whispered in awe.</p>
-</div>
-<div id="page-57" class="page-content-container">
+    <p>With the golem defeated, they entered the library proper. It was a breathtaking sight, a massive cavern filled with towering shelves of water-logged books and glowing crystals that cast an ethereal light on the scene. The air was thick with the scent of wet paper and ancient magic. "This place is a treasure trove," Arjun whispered in awe. "Imagine the knowledge stored here."</p>
+
     <h2>Chapter 24: The First Clue</h2>
-    <p>They began their search, a daunting task in the vast library. Anirudh, using the symbol on his pendant as a guide, found a hidden inscription on one of the shelves. It was a riddle, the first clue in a long and dangerous scavenger hunt for the Scroll of Shadows.</p>
-</div>
-<div id="page-58" class="page-content-container">
+    <p>They began their search, a daunting task in the vast library. Anirudh, using the symbol on his pendant as a guide, found a hidden inscription on one of the shelves. It was a riddle, the first clue in a long and dangerous scavenger hunt for the Scroll of Shadows. *'Where the twin moons cast their silver gaze, and the river of stars flows, there you will find the path.'*</p>
+
     <h2>Chapter 25: A Rival's Intellect</h2>
-    <p>Arjun, with his vast knowledge of magical lore, solved the riddle. It pointed them to a section of the library that dealt with celestial alignments. "The scroll is hidden in a room that is only revealed when the twin moons are in perfect alignment," he explained. They had to hurry. The alignment was only a few hours away.</p>
-</div>
-<div id="page-59" class="page-content-container">
+    <p>Arjun, with his vast knowledge of magical lore, solved the riddle. "It's not a place," he said, his eyes gleaming with excitement. "It's a time. The scroll is hidden in a room that is only revealed when the twin moons are in perfect alignment. And according to this star chart," he said, pointing to a complex diagram on the wall, "that happens tonight. We have to hurry."</p>
+
     <h2>Chapter 26: The Water Trap</h2>
-    <p>Their path was blocked by a massive chamber that was rapidly filling with water. There was no visible exit. "A classic pressure plate puzzle," Arjun said, but there was no time to think. The water was rising fast. Anirudh, using his strength, held a collapsing archway open while Arjun frantically searched for the release mechanism.</p>
-</div>
-<div id="page-60" class="page-content-container">
+    <p>Their path was blocked by a massive chamber that was rapidly filling with water. There was no visible exit. "A classic pressure plate puzzle," Arjun said, his voice tight with urgency. "But there's no time to think. The water is rising fast." Anirudh, using his strength, held a collapsing archway open while Arjun frantically searched for the release mechanism.</p>
+
     <h2>Chapter 27: A Moment of Trust</h2>
-    <p>Arjun found the mechanism, a series of runes that had to be activated in a specific order. But he couldn't reach it. He had to trust Anirudh to hold the archway long enough. For the first time, they were completely dependent on each other. Anirudh's arms screamed in protest, but he held on, his will a fortress of stone.</p>
+    <p>Arjun found the mechanism, a series of runes that had to be activated in a specific order. But he couldn't reach it. He had to trust Anirudh to hold the archway long enough. "I need you to throw me!" Arjun yelled over the roar of the water. Anirudh didn't hesitate. With a mighty heave, he threw Arjun across the chamber. Arjun, his body crackling with magical energy, landed perfectly and activated the runes just as the archway collapsed. The water drained away, revealing a hidden passage. For the first time, they were completely dependent on each other, and a new, grudging respect had formed between them.</p>
 </div>
-<div id="page-61" class="page-content-container">
+<div id="page-61-69-reexpanded" class="page-content-container">
     <h2>Chapter 28: The Chamber of Echoes</h2>
-    <p>They escaped the water trap, only to find themselves in a chamber that echoed with whispers of the past. They saw visions of the Alchemist King, of his great power, and of the terrible betrayal that led to his downfall. Anirudh saw a vision of his mother, her face clear for the first time, and his heart ached with a profound sense of loss.</p>
-</div>
-<div id="page-62" class="page-content-container">
+    <p>They escaped the water trap, only to find themselves in a circular chamber where the very air seemed to hum with the whispers of the past. The walls were covered in murals depicting the life of the Alchemist King. As they walked, the murals came to life, showing them visions of his great power, his wisdom, and the terrible betrayal that led to his downfall. Anirudh saw his father, not as a king, but as a man who loved his family and his people. He saw a vision of his mother, her face clear for the first time, her laughter echoing in the chamber. The sense of loss was a physical blow, and he stumbled, his heart aching.</p>
+
     <h2>Chapter 29: The Weight of Legacy</h2>
-    <p>The visions shook them both. Arjun saw the destructive potential of unchecked power, and Anirudh felt the immense weight of his legacy. He was the heir to a power that could save the world or destroy it. The pendant around his neck pulsed with a sorrowful energy.</p>
-</div>
-<div id="page-63" class="page-content-container">
+    <p>The visions shook them both. Arjun saw the destructive potential of unchecked power, and the folly of his own arrogance. He saw a reflection of himself in the king's betrayers. Anirudh felt the immense weight of his legacy. He was the heir to a power that could save the world or destroy it. The pendant around his neck pulsed with a sorrowful energy, as if it too remembered the pain of the past.</p>
+
     <h2>Chapter 30: The Second Clue</h2>
-    <p>In the Chamber of Echoes, they found the second clue, etched into the base of a statue of the Alchemist King. It was a star chart, pointing them to the final location of the scroll: the Celestial Orrery, a massive, clockwork model of the solar system.</p>
-</div>
-<div id="page-64" class="page-content-container">
+    <p>In the center of the Chamber of Echoes, they found a statue of the Alchemist King. At its base was the second clue, etched into the stone. It was a star chart, pointing them to the final location of the scroll: the Celestial Orrery, a massive, clockwork model of the solar system.</p>
+
     <h2>Chapter 31: The Celestial Orrery</h2>
-    <p>The Celestial Orrery was a magnificent, awe-inspiring sight. Massive golden spheres representing the planets and moons moved in a slow, silent dance, suspended in the air by a powerful magical field. In the center of the room, on a raised platform, was a single, ornate scroll case.</p>
-</div>
-<div id="page-65" class="page-content-container">
+    <p>The Celestial Orrery was a magnificent, awe-inspiring sight. Massive golden spheres representing the planets and moons moved in a slow, silent dance, suspended in the air by a powerful magical field. The room was filled with a soft, golden light, and the air hummed with a powerful, ancient magic. In the center of the room, on a raised platform, was a single, ornate scroll case.</p>
+
     <h2>Chapter 32: The Final Guardian</h2>
-    <p>As they approached the scroll, a new guardian emerged from the shadows. It was a creature of pure energy, a being of light and shadow that moved with blinding speed. It was a magical construct, far more powerful than the stone golem. "This one is mine," Arjun said, his eyes blazing with determination.</p>
-</div>
-<div id="page-66" class="page-content-container">
+    <p>As they approached the scroll, a new guardian emerged from the shadows. It was a creature of pure energy, a being of light and shadow that moved with blinding speed. It was a magical construct, far more powerful than the stone golem. "This one is mine," Arjun said, his eyes blazing with a newfound determination. "I will not fail this time."</p>
+
     <h2>Chapter 33: A Display of Power</h2>
-    <p>Arjun unleashed the full extent of his magical power. It was a dazzling display of elemental fury, a storm of lightning, fire, and ice. But the creature was too fast, too ethereal. It seemed to be everywhere at once. Arjun was powerful, but he was also reckless, and he was quickly exhausting his energy.</p>
-</div>
-<div id="page-67" class="page-content-container">
+    <p>Arjun unleashed the full extent of his magical power. It was a dazzling display of elemental fury, a storm of lightning, fire, and ice. But the creature was too fast, too ethereal. It seemed to be everywhere at once, its form shifting and changing, making it impossible to land a solid blow. Arjun was powerful, but he was also reckless, and he was quickly exhausting his energy.</p>
+
     <h2>Chapter 34: A Warrior's Strategy</h2>
-    <p>Anirudh saw that Arjun's frontal assault was failing. He had to think like a warrior, not a mage. He watched the creature's movements, looking for a pattern, a weakness. He saw that it always returned to the center of the room to recharge its energy. That was their only chance.</p>
-</div>
-<div id="page-68" class="page-content-container">
+    <p>Anirudh saw that Arjun's frontal assault was failing. He had to think like a warrior, not a mage. He watched the creature's movements, looking for a pattern, a weakness. He saw that it always returned to the center of the room to recharge its energy from the orrery itself. That was their only chance.</p>
+
     <h2>Chapter 35: The Perfect Team</h2>
-    <p>Anirudh explained his plan to Arjun. "I need you to create a diversion, a big one. I'll do the rest." Arjun, exhausted and humbled, agreed. He summoned a massive thunderstorm, a chaotic spectacle of light and sound that drew the creature's attention. While it was distracted, Anirudh used his staff to disrupt the magical field that powered the orrery.</p>
-</div>
-<div id="page-69" class="page-content-container">
+    <p>"Arjun, I need you to create a diversion!" Anirudh yelled. "A big one! I have a plan!"</p>
+    <p>Arjun, exhausted and humbled, nodded. He summoned a massive thunderstorm, a chaotic spectacle of light and sound that drew the creature's attention. While it was distracted, Anirudh used his staff to disrupt the magical field that powered the orrery. He didn't try to destroy it, but to change its frequency, to create a disharmony in the flow of energy.</p>
+
     <h2>Chapter 36: The Scroll is Theirs</h2>
-    <p>With the magical field disrupted, the creature flickered and died. The Celestial Orrery ground to a halt. The room was silent. They had done it. Anirudh walked to the platform and picked up the scroll case. The Scroll of Shadows was theirs.</p>
+    <p>The creature shrieked as the orrery's energy turned against it. With the magical field disrupted, the creature flickered and died. The Celestial Orrery ground to a halt. The room was silent. They had done it. Anirudh walked to the platform and picked up the scroll case. The Scroll of Shadows was theirs.</p>
 </div>
-<div id="page-70" class="page-content-container">
+<div id="page-70-73-reexpanded" class="page-content-container">
     <h2>Chapter 37: The Betrayal</h2>
-    <p>As they turned to leave, a new figure appeared in the doorway. It was Master Leela, the wise old instructor who had helped Anirudh. But her eyes were cold, her smile venomous. "Thank you for retrieving the scroll for me, boys," she said, her voice dripping with malice. "I'll take it from here."</p>
-</div>
-<div id="page-71" class="page-content-container">
+    <p>As they turned to leave, a new figure appeared in the doorway. It was Master Leela, the wise old instructor who had helped Anirudh. But her eyes were cold, her smile venomous. "Thank you for retrieving the scroll for me, boys," she said, her voice dripping with malice. "I must admit, I had my doubts about you, Arjun. But you have proven to be a most useful pawn."</p>
+    <p>"Master Leela, what is the meaning of this?" Arjun demanded, his voice a mixture of confusion and anger.</p>
+    <p>"The meaning," she said with a cruel laugh, "is that the age of foolish old men and their sentimental rules is over. A new era of power is about to begin. And I will be its queen."</p>
+
     <h2>Chapter 38: The True Enemy</h2>
-    <p>Master Leela was the leader of the hidden faction. She had been manipulating them all along, using the tournament and the scroll hunt as a means to get what she wanted. She was a descendant of the very people who had betrayed the Alchemist King, and she sought to reclaim his power for herself.</p>
-</div>
-<div id="page-72" class="page-content-container">
+    <p>Master Leela was the leader of the hidden faction, the Serpent's Hand. She had been manipulating them all along, using the tournament and the scroll hunt as a means to get what she wanted. She was a descendant of the very people who had betrayed the Alchemist King, and she sought to reclaim his power for herself. "Your father was a fool, Anirudh," she sneered. "He had the power to rule, but he chose to serve. A mistake I do not intend to repeat."</p>
+
     <h2>Chapter 39: A Desperate Escape</h2>
-    <p>Anirudh and Arjun were trapped. Master Leela was too powerful. But Anirudh had one last trick up his sleeve. He slammed his staff on the ground, shattering the control panel for the orrery. The massive celestial spheres began to fall, creating chaos and a diversion. They ran, the sound of the collapsing orrery echoing behind them.</p>
-</div>
-<div id="page-73" class="page-content-container">
+    <p>Anirudh and Arjun were trapped. Master Leela was too powerful, her magic a storm of dark energy they could not hope to match. But Anirudh had one last trick up his sleeve. He looked at Arjun and nodded towards the control panel of the orrery. Arjun understood immediately. While Arjun created a diversion, a blinding flash of light that momentarily stunned Leela, Anirudh slammed his staff on the ground, shattering the control panel for the orrery. The massive celestial spheres began to fall, creating chaos and a diversion. They ran, the sound of the collapsing orrery echoing behind them, a symphony of destruction.</p>
+
     <h2>Chapter 40: A New Resolve</h2>
-    <p>They escaped the Sunken Library, bruised, battered, and betrayed. They had the scroll, but their enemy was more powerful than they had ever imagined. The tournament was no longer about winning. It was about survival. They had to warn the others, to expose Master Leela's conspiracy before it was too late. Their rivalry was now a bond, forged in the fires of betrayal and a shared purpose.</p>
+    <p>They escaped the Sunken Library, bruised, battered, and betrayed. They had the scroll, but their enemy was more powerful than they had ever imagined. The tournament was no longer about winning. It was about survival. They had to warn the others, to expose Master Leela's conspiracy before it was too late. Their rivalry was now a bond, forged in the fires of betrayal and a shared purpose. They were no longer just a warrior and a mage. They were brothers.</p>
 </div>
 <!-- ACT 4: THE TOURNAMENT -->
-<div id="page-74" class="page-content-container">
+<div id="page-74-77-reexpanded" class="page-content-container">
     <h1>Act 4: The Tournament</h1>
     <h2>Chapter 41: The Calm Before the Storm</h2>
-    <p>The day of the tournament arrived. The academy was a riot of color and celebration, but for Anirudh and Arjun, it was a day of dread. They knew that Master Leela and her followers would be watching, waiting for an opportunity to strike. They had to be careful, to play their part until they could reveal the truth.</p>
-</div>
-<div id="page-75" class="page-content-container">
+    <p>The day of the tournament arrived. The Vidyut academy was a riot of color and celebration, banners of the two academies snapping in the wind. But for Anirudh and Arjun, it was a day of dread. They knew that Master Leela and her followers, the Serpent's Hand, would be watching, waiting for an opportunity to strike. They had to be careful, to play their part until they could reveal the truth. "Stay close," Arjun muttered to Anirudh as they walked towards the arena. "And trust no one."</p>
+
     <h2>Chapter 42: The Opening Ceremony</h2>
-    <p>The tournament began with a grand opening ceremony. Students from Kanjiram and Vidyut marched into the arena, their faces a mixture of pride and nervousness. Anirudh saw Rohan in the Kanjiram delegation, his expression as arrogant as ever. He had no idea of the danger they were all in.</p>
-</div>
-<div id="page-76" class="page-content-container">
+    <p>The tournament began with a grand opening ceremony. Students from Kanjiram and Vidyut marched into the arena, their faces a mixture of pride and nervousness. Anirudh saw Rohan in the Kanjiram delegation, his expression as arrogant as ever. He had no idea of the danger they were all in. Anirudh also saw Master Elara and Instructor Kael from Kanjiram, their faces grim. They knew something was wrong.</p>
+
     <h2>Chapter 43: The First Round</h2>
-    <p>The first round of the tournament was a series of one-on-one duels. Anirudh was pitted against a Kanjiram student who specialized in defensive techniques. It was a frustrating fight, but Anirudh's relentless pressure eventually broke through, earning him a hard-fought victory.</p>
-</div>
-<div id="page-77" class="page-content-container">
+    <p>The first round of the tournament was a series of one-on-one duels. Anirudh was pitted against a Kanjiram student, a boy named Kenji who specialized in defensive earth magic. It was a frustrating fight. Kenji was a wall, his earth shields absorbing Anirudh's attacks. But Anirudh was relentless, his attacks a constant storm of pressure. He used his agility and unorthodox style to chip away at Kenji's defenses, finally breaking through and earning a hard-fought victory. The crowd, especially the Vidyut students, cheered for the outsider who had defeated one of Kanjiram's best.</p>
+
     <h2>Chapter 44: A Coded Message</h2>
-    <p>Arjun, meanwhile, faced a Vidyut student who he suspected was one of Leela's followers. During the duel, his opponent subtly used a forbidden magical gesture, a coded message. Arjun won the duel, but he knew he was being watched.</p>
+    <p>Arjun, meanwhile, faced a Vidyut student he suspected was one of Leela's followers. The student was a powerful mage, but his eyes held a fanatical gleam that made Arjun uneasy. During the duel, his opponent subtly used a forbidden magical gesture, a coded message. Arjun recognized it from the letters Anirudh had found. It was the sign of the Serpent's Hand. Arjun, his face a mask of cold fury, ended the duel quickly and decisively. He had won the duel, but he knew he was being watched. The conspiracy was real, and it was all around them.</p>
 </div>
-<div id="page-78" class="page-content-container">
+<div id="page-78-83-reexpanded" class="page-content-container">
     <h2>Chapter 45: A Secret Meeting</h2>
-    <p>That night, they met in secret to discuss their next move. They had to get the scroll to someone they could trust, someone with the power to stop Leela. They decided to seek out the headmaster of Kanjiram, a man known for his wisdom and integrity.</p>
-</div>
-<div id="page-79" class="page-content-container">
+    <p>That night, Anirudh and Arjun met in secret in the deserted library. "We can't do this alone," Anirudh said, his voice low. "We need to get the scroll to someone who can stop Leela. Someone with authority."</p>
+    <p>"The headmaster of Kanjiram," Arjun said immediately. "He is known for his wisdom and integrity. But getting to him will not be easy. The Kanjiram delegation is heavily guarded."</p>
+
     <h2>Chapter 46: An Unexpected Encounter</h2>
-    <p>As they made their way to the Kanjiram delegation's quarters, they ran into Rohan. He was suspicious of their late-night wanderings and accused them of cheating. Anirudh, seeing no other choice, told him everything. Rohan was skeptical, but the urgency in Anirudh's voice gave him pause.</p>
-</div>
-<div id="page-80" class="page-content-container">
+    <p>As they made their way to the Kanjiram delegation's quarters, a figure stepped out of the shadows, blocking their path. It was Rohan. "Sneaking around in the middle of the night?" he said, his voice laced with suspicion. "Planning to cheat your way to victory, orphan?"</p>
+    <p>"We don't have time for this, Rohan," Arjun snapped. "Step aside."</p>
+    <p>"Not until you tell me what you are up to," Rohan said, his hand on the hilt of his sword.</p>
+    <p>Anirudh looked at Arjun, then back at Rohan. He saw the same arrogance, but also a flicker of something else in Rohan's eyes: a sense of honor. He made a decision. "We are not cheating," Anirudh said. "We are trying to save the academies. Both of them." He then told Rohan everything: about the conspiracy, the Serpent's Hand, and Master Leela's plan.</p>
+
     <h2>Chapter 47: A New Ally</h2>
-    <p>Rohan, for all his arrogance, was a man of honor. The idea of a conspiracy within the academies disgusted him. He agreed to help them, to use his influence to get them an audience with the Kanjiram headmaster. The three rivals were now united against a common enemy.</p>
-</div>
-<div id="page-81" class="page-content-container">
+    <p>Rohan listened, his expression shifting from suspicion to shock, and then to a cold fury. For all his arrogance, he was a man of honor. The idea of a conspiracy within the academies, a plot that threatened to destroy everything he had been taught to revere, disgusted him. "I will help you," he said, his voice firm. "My father is General Kael. He is close to the headmaster. I can get you an audience." The three rivals, once enemies, were now united against a common foe.</p>
+
     <h2>Chapter 48: The Headmaster's Council</h2>
-    <p>They met with the headmasters of both academies. At first, the headmasters were disbelieving. Master Leela was a respected member of the Vidyut faculty. But the evidence in the scroll was irrefutable. It contained not only the secrets of the Wildblood Beasts, but also a detailed plan for Leela's coup.</p>
-</div>
-<div id="page-82" class="page-content-container">
+    <p>They met with the headmasters of both academies in a secret chamber deep within the Vidyut academy. At first, the headmasters were disbelieving. Master Leela was a respected member of the Vidyut faculty. But the evidence in the scroll was irrefutable. It contained not only the secrets of the Wildblood Beasts, but also a detailed plan for Leela's coup, signed with her own seal.</p>
+    <p>"This is an act of treason!" the Kanjiram headmaster roared, his face a mask of fury.</p>
+
     <h2>Chapter 49: The Trap is Sprung</h2>
-    <p>As they were meeting, Leela made her move. She and her followers stormed the arena, using forbidden magic to subdue the crowd. She had a Wildblood Beast with her, a monstrous creature of shadow and fury, held in check by a powerful spell.</p>
-</div>
-<div id="page-83" class="page-content-container">
+    <p>As they were planning their next move, a tremor shook the entire academy. The sound of screams echoed from the arena. They rushed to a balcony overlooking the tournament grounds. Leela stood in the center of the arena, her followers surrounding her. She held a glowing amulet in her hand, and beside her stood a monstrous creature of shadow and fury, a Wildblood Beast, its eyes glowing with a malevolent light.</p>
+
     <h2>Chapter 50: The Final Battle Begins</h2>
-    <p>"The age of the academies is over!" Leela declared, her voice booming across the arena. "A new era of power begins now!" The headmasters, along with Anirudh, Arjun, and Rohan, rushed to confront her. The final battle had begun.</p>
+    <p>"The age of the academies is over!" Leela declared, her voice booming across the arena, amplified by magic. "A new era of power begins now! And I will be its queen!" The headmasters, along with Anirudh, Arjun, and Rohan, rushed to confront her. The final battle had begun.</p>
 </div>
-<div id="page-84" class="page-content-container">
+<div id="page-84-93-reexpanded" class="page-content-container">
     <h2>Chapter 51: A Three-Pronged Attack</h2>
-    <p>Arjun and Rohan, combining their skills, took on the Wildblood Beast. Arjun's elemental magic and Rohan's disciplined swordsmanship made them a formidable team. They fought with a desperate courage, trying to keep the beast from rampaging through the crowd.</p>
-</div>
-<div id="page-85" class="page-content-container">
+    <p>Arjun and Rohan, their rivalry forgotten in the face of a common enemy, took on the Wildblood Beast. Arjun's elemental magic, a whirlwind of lightning and fire, crashed against the beast's shadowy hide. Rohan's disciplined swordsmanship, a dance of deadly precision, sought to find a weakness in the creature's defenses. They fought with a desperate courage, a formidable team of magic and steel, trying to keep the beast from rampaging through the terrified crowd.</p>
+
     <h2>Chapter 52: The Power of the Pendant</h2>
-    <p>Anirudh faced Leela. She was far more powerful than he was, her mastery of forbidden magic almost absolute. But Anirudh had something she didn't. As she unleashed a powerful spell, the Crimson Pendant on his chest flared to life, absorbing the dark energy. He felt a surge of power, a connection to the ancient magic of his ancestors.</p>
-</div>
-<div id="page-86" class="page-content-container">
+    <p>Anirudh faced Leela. She was far more powerful than he was, her mastery of forbidden magic almost absolute. She unleashed a torrent of dark energy, a wave of pure hatred that threatened to consume him. But Anirudh had something she didn't. As the dark energy washed over him, the Crimson Pendant on his chest flared to life, absorbing the magic. He felt a surge of power, a connection to the ancient magic of his ancestors, the Alchemist Kings.</p>
+
     <h2>Chapter 53: The King's Blood</h2>
-    <p>Leela was stunned. "The blood of the Alchemist King," she whispered, her eyes wide with a mixture of fear and greed. "It's true. You are his heir." She redoubled her attack, desperate to possess the power that was rightfully hers.</p>
-</div>
-<div id="page-87" class="page-content-container">
+    <p>Leela was stunned. "The blood of the Alchemist King," she whispered, her eyes wide with a mixture of fear and greed. "It's true. You are his heir." She redoubled her attack, her desire for the power that was rightfully hers, in her mind, turning her into a maelstrom of destruction. "That power should be mine!" she shrieked, her voice filled with a mad fury.</p>
+
     <h2>Chapter 54: An Unlikely Hero</h2>
-    <p>The tide of the battle turned when Rohan, seeing an opening, threw his sword. It wasn't aimed at the beast, but at the amulet Leela was using to control it. The sword struck true, shattering the amulet. The beast, now free from her control, turned on its former master.</p>
-</div>
-<div id="page-88" class="page-content-container">
+    <p>The tide of the battle turned when Rohan, seeing an opening, made a desperate gamble. He threw his sword, not at the beast, but at the amulet Leela was using to control it. It was a throw of incredible skill and precision. The sword struck true, shattering the amulet. The beast, now free from her control, turned on its former master, its roar a symphony of pure, untamed rage.</p>
+
     <h2>Chapter 55: The Beast's Fury</h2>
     <p>The Wildblood Beast, a creature of pure chaos, attacked Leela with a savage fury. She was powerful, but she could not control the monster she had unleashed. Anirudh, Arjun, and Rohan could only watch as the beast and the sorceress battled, their combined power threatening to tear the arena apart.</p>
-</div>
-<div id="page-89" class="page-content-container">
+
     <h2>Chapter 56: A Noble Sacrifice</h2>
-    <p>The beast was about to deliver a final, killing blow when the Kanjiram headmaster stepped in. He used a powerful, forbidden spell to banish the beast, sacrificing his own life force in the process. He collapsed, his body fading into light, a final act of courage that saved them all.</p>
-</div>
-<div id="page-90" class="page-content-container">
+    <p>The beast was about to deliver a final, killing blow when the Kanjiram headmaster stepped forward. He was old, but his eyes burned with a fierce light. He began to chant in an ancient, forgotten tongue, his body glowing with a golden light. He was using a powerful, forbidden spell to banish the beast, a spell that required the ultimate sacrifice: his own life force. He collapsed, his body fading into light, a final act of courage that saved them all. "Live on, young heroes," he whispered, his voice a faint echo on the wind. "Protect the future."</p>
+
     <h2>Chapter 57: The Aftermath</h2>
-    <p>With the beast gone and her plan in ruins, Leela was captured. Her followers were rounded up. The tournament was over, but the celebration had turned to mourning. The headmaster's sacrifice had saved them, but it had come at a terrible cost.</p>
-</div>
-<div id="page-91" class="page-content-container">
+    <p>With the beast gone and her plan in ruins, a wounded and exhausted Leela was captured. Her followers were rounded up. The tournament was over, but the celebration had turned to mourning. The headmaster's sacrifice had saved them, but it had come at a terrible cost. The silence in the arena was a heavy shroud, broken only by the weeping of the students.</p>
+
     <h2>Chapter 58: A New Understanding</h2>
-    <p>In the aftermath, Anirudh, Arjun, and Rohan stood together, no longer rivals, but brothers in arms. They had faced death together and had emerged stronger. They had learned the true meaning of power, honor, and sacrifice. The rivalry between their academies seemed petty and insignificant now.</p>
-</div>
-<div id="page-92" class="page-content-container">
+    <p>In the aftermath, Anirudh, Arjun, and Rohan stood together, no longer rivals, but brothers in arms. They had faced death together and had emerged stronger. They had learned the true meaning of power, honor, and sacrifice. The rivalry between their academies seemed petty and insignificant now. "He was a true warrior," Rohan said, his voice thick with emotion, as he looked at the spot where the headmaster had vanished.</p>
+
     <h2>Chapter 59: The Road Ahead</h2>
-    <p>Anirudh finally had some of the answers he was looking for. He knew who he was, and he knew the danger he faced. The pendant was not just a key to his past, but a beacon to his enemies. His journey was far from over. He had to learn to control the power within him, to become the hero his parents had always known he could be.</p>
-</div>
-<div id="page-93" class="page-content-container">
+    <p>Anirudh finally had some of the answers he was looking for. He knew who he was, and he knew the danger he faced. The pendant was not just a key to his past, but a beacon to his enemies. His journey was far from over. He had to learn to control the power within him, to become the hero his parents had always known he could be. He looked at his friends, at the shared determination in their eyes, and he knew he would not have to walk the path alone.</p>
+
     <h2>Chapter 60: A Shared Destiny</h2>
     <p>Arjun and Rohan pledged to help him. They knew that the threat of the Wildblood Beasts and those who would seek to control them was not gone. The world needed heroes, and the three of them, the orphan, the mage, and the warrior, would face the future together. Their journey had just begun, a shared destiny that would shape the fate of their world.</p>
 </div>
 <!-- ACT 5: THE FORGE OF THE SPIRIT -->
-<div id="page-94" class="page-content-container">
+<div id="page-94-99-reexpanded" class="page-content-container">
     <h1>Act 5: The Forge of the Spirit</h1>
     <h2>Chapter 1: The Forge of the Spirit</h2>
     <p>At the great gates of Kanjiram Academy, Rohan stood like a sentinel of disapproval, his arms crossed. "So, it's true," he said, his voice a silken weapon. "You're running away. You face a little hardship, a little real discipline, and you flee to the wilds with this... hedge-wizard."</p>
-    <p>Anirudh met his gaze, his own expression a calm lake hiding unfathomable depths. "I'm not running away, Rohan. I'm walking towards something."</p>
+    <p>Anirudh met his gaze, his own expression a calm lake hiding unfathomable depths. "I'm not running away, Rohan. I'm walking towards something. A different path."</p>
     <p>Arjun placed a calming hand on Anirudh's shoulder, his eyes twinkling with ancient amusement. "Every river finds its own path to the sea, young Rohan," he said, his voice like stones smoothed by a current. "Some are wide and straight, a testament to their power. Others must carve their way through mountains, a testament to their will. Do not mistake a difficult path for a wrong one." Rohan scoffed, a sharp, ugly sound, but he stepped aside. His eyes, however, never left Anirudh, and in their depths was a promise of a future reckoning.</p>
     <p>The gates of Kanjiram closed behind them, and the world opened up. For weeks, they traveled, leaving the manicured lands of the academy's domain for the rugged, untamed wilderness. Arjun's lessons were not in lectures, but in the rustle of leaves, the scent of rain, the taste of wild berries. "The world is a book, Anirudh," Arjun said one evening, gesturing to the star-dusted sky. "Kanjiram teaches you to read the footnotes. I will teach you to read the poetry." In the quiet of the wilderness, Anirudh began to unlearn the harsh lessons of his youth—the need to fight for every scrap, to trust no one. He learned to breathe. One night, by a crackling fire, Arjun finally explained his choice. "Rohan is a perfect sword, forged and polished in the finest fires. He will win many battles," he said, his gaze distant. "But you, Anirudh... you are the unrefined mountain ore. Rich with potential, but useless as you are. I do not want to make you a sword. I want to teach you how to become the forge."</p>
-</div>
-<div id="page-95" class="page-content-container">
+
     <h2>Chapter 2: The Whispering Leaf</h2>
     <p>The true training began in a high mountain pass, where the wind sang a lonely song through the rocks. Arjun's first challenge seemed simple, almost a joke. He picked up a single, dry leaf. "Make it dance," he said.</p>
-    <p>For hours, Anirudh failed. He pushed his will at the leaf, channeling his energy, his frustration mounting with every twitch and flutter that wasn't his own. He tried to command it, to force it, to treat it as an opponent to be subdued. The leaf lay stubbornly on the rock.</p>
+    <p>For hours, Anirudh failed. He pushed his will at the leaf, channeling his energy, his frustration mounting with every twitch and flutter that wasn't his own. He tried to command it, to force it, to treat it as an opponent to be subdued. The leaf lay stubbornly on the rock. "Useless!" he finally yelled in frustration, throwing the leaf to the ground.</p>
     <p>"You are still thinking like a student at Kanjiram!" Arjun's voice cut through his concentration. "You see a nail, and you reach for a hammer! This is not a technique to be mastered, Anirudh. It is a relationship to be built. The wind is not your servant. It is your partner. You are afraid to let go, to trust in something other than your own strength."</p>
     <p>Arjun's words struck a chord deep within him. He remembered his mother's plea to *live*, not just survive. He let out a long breath, releasing his frustration, his ambition, his fear. He looked at the leaf, and for the first time, he listened. He felt the currents of the air, the subtle eddies and flows. He didn't command. He invited. He extended his own inner calm, his own spirit, and asked the wind to dance with him. And it did. The leaf rose from the rock, not in a violent gust, but in a gentle, swirling spiral, dancing in the air before him, a silent partner in a moment of pure harmony. He had learned the first note of the world's song.</p>
-</div>
-<div id="page-96" class="page-content-container">
+
     <h2>Chapter 3: The River's Wisdom</h2>
     <p>Their journey took them to the banks of a roaring river, a torrent of white water that carved its way through a deep canyon. "Your next lesson," Arjun said, pointing to a massive boulder in the middle of the current. "That rock is strong. It is unyielding. And every day, the river wears it down. It is a fool's strength. The water, however, is soft. It yields. It flows. And it has carved this entire canyon. That is true power."</p>
     <p>Arjun tasked Anirudh with crossing the river. Not by swimming against the current, but by understanding it. Anirudh spent a full day just watching, feeling the pull of the water, the way it curled around the rocks, the hidden pathways of lesser resistance. He learned that the river's strength was not uniform. There were places of immense power, and places of surprising calm. He learned to see the river not as an obstacle, but as a map.</p>
     <p>When he finally entered the water, he did not fight it. He yielded to it, letting it guide him, using its own power to carry him across. He was not a warrior battling a foe; he was a leaf on the current, a part of the river's own dance. He reached the other side, exhausted but exhilarated, the river's wisdom now a part of him.</p>
-</div>
-<div id="page-97" class="page-content-container">
+
     <h2>Chapter 4: The Silent Mountain</h2>
-    <p>High in the snow-capped peaks, where the air was thin and the silence was absolute, Arjun gave Anirudh his next task. He was to sit before a sheer rock face and do nothing but observe. For days, Anirudh sat, his frustration growing. He saw nothing but rock. He felt nothing but the biting cold.</p>
-    <p>"You are looking, but you are not seeing," Arjun told him one evening. "You see a dead thing. A wall. But the mountain is alive. It breathes. It has a history. It has a spirit. You must learn to listen to its silence."</p>
+    <p>High in the snow-capped peaks, where the air was thin and the silence was absolute, Arjun gave Anirudh his next task. He was to sit before a sheer rock face and do nothing but observe. For days, Anirudh sat, his frustration growing. He saw nothing but rock. He felt nothing but the biting cold. "This is pointless," he complained to Arjun one evening. "I am a warrior, not a monk. I need to train, not stare at a rock."</p>
+    <p>"You are looking, but you are not seeing," Arjun told him. "You see a dead thing. A wall. But the mountain is alive. It breathes. It has a history. It has a spirit. You must learn to listen to its silence."</p>
     <p>Anirudh, desperate, let go of his expectations. He stopped trying to *find* something. He simply sat, and he listened. He felt the slow, ancient vibration of the mountain, the deep, rumbling life within the stone. He saw the subtle story of the rock face - the scars of ancient glaciers, the faint lines of water that had flowed for millennia, the tiny, tenacious plants that clung to life in its cracks. He realized that the mountain's strength was not in its hardness, but in its endurance, its quiet, unyielding presence. He had learned to see the life in the lifeless, the story in the silence.</p>
-</div>
-<div id="page-98" class="page-content-container">
+
     <h2>Chapter 5: A Fateful Encounter</h2>
-    <p>Their path led them to a small, forgotten village nestled in a valley, a place where the air was thick with a strange, sweet sickness. The people were listless, their eyes dull, a creeping lethargy draining the life from them. In the center of the village, a young woman moved among the sick, her face a mask of determined compassion. Her name was Meera.</p>
+    <p>Their path led them to a small, forgotten village nestled in a valley, a place where the air was thick with a strange, sweet sickness. The people were listless, their eyes dull, a creeping lethargy draining the life from them. In the center of the village, a young woman moved among the sick, her face a mask of determined compassion. Her name was Meera. She had kind eyes and a gentle touch, and she moved with a quiet grace that reminded Anirudh of the river.</p>
     <p>Anirudh and Arjun watched as she tended to the villagers, her touch gentle, her voice a soothing balm. But her efforts were not enough. The sickness was too strong, a creeping shadow that seemed to emanate from the forest itself. Anirudh, moved by the sight of a small child coughing weakly in her mother's arms, felt the familiar urge to *do* something, to fight this unseen enemy.</p>
-    <p>Arjun, however, placed a hand on his arm. "This is not a battle of swords, Anirudh," he said quietly. "This is a battle of a different kind."</p>
-</div>
-<div id="page-99" class="page-content-container">
+    <p>Arjun, however, placed a hand on his arm. "This is not a battle of swords, Anirudh," he said quietly. "This is a battle of a different kind. Watch. And learn."</p>
+
     <h2>Chapter 6: The Moonblood's Light</h2>
     <p>That night, a child's fever spiked. The village healer was helpless. Meera, her face pale with resolve, knelt by the child's side. She closed her eyes, and a soft, silver light began to emanate from her hands. The light flowed into the child, a gentle, pulsing wave of pure life energy. The child's breathing eased, the fever broke. The sickness, for a moment, had been pushed back.</p>
     <p>Later, Meera explained. She was a Moonblood Healer, a descendant of a long line of guardians sworn to protect the bloodline of the Alchemist King. The pendant on Anirudh's chest was the sign she had been waiting for her entire life. "The sickness in this village is not natural," she explained, her eyes dark with worry. "It is a symptom of the Void's touch, a creeping corruption that drains the life from the land and its people. My light can hold it back, but it cannot cure it." Her duty was clear. She would join Anirudh and Arjun, to be his anchor, his guide, and his protector. The three of them, the warrior, the master, and the healer, were now bound by a shared destiny.</p>
 </div>
-<div id="page-100" class="page-content-container">
+<div id="page-100-107-reexpanded" class="page-content-container">
     <h2>Chapter 7: The Proving Ground</h2>
     <p>The Tournament of Rising Suns was a grand affair, a gathering of the most promising young warriors from across the realms. Anirudh, now accompanied by Arjun and Meera, entered not for glory, but to test the limits of his new understanding. His first opponent was a mountain of a man, a brawler named Korg who fought with two massive, spiked gauntlets. The crowd roared for the spectacle of violence they expected.</p>
     <p>Anirudh, remembering the river's wisdom, did not meet force with force. He became the water. He flowed around Korg's clumsy, powerful strikes, his feet barely seeming to touch the ground. He used the brawler's own momentum against him, a gentle touch here, a subtle shift in balance there. Korg, enraged and confused, found himself fighting a phantom, a ghost that was always just beyond his reach. The fight ended not with a bang, but with a whisper. Korg, lunging in a final, desperate charge, found himself suddenly off-balance, stumbling, and landing face-first in the dust, exhausted and defeated. Anirudh hadn't landed a single direct blow.</p>
-</div>
-<div id="page-101" class="page-content-container">
+
     <h2>Chapter 8: A Rival's Gaze</h2>
     <p>From the stands, Rohan watched, his expression a mask of cold disbelief. He had expected Anirudh to be crushed. Instead, he had witnessed... a trick. A dance. A coward's victory. He saw Korg, a warrior of immense and honest power, defeated without a single meaningful blow being struck. It was an insult to the very spirit of combat.</p>
     <p>"He is a charlatan," Rohan muttered to one of his Kanjiram companions. "He uses cheap tricks and illusions to avoid a true fight. He has no honor." But even as he said the words, a small, unsettling seed of doubt took root in his mind. He had seen the look on Korg's face - not just anger, but confusion, as if he had been fighting the wind itself. Rohan pushed the thought away. He was a warrior of Kanjiram. He believed in discipline, in form, in the overwhelming power of a perfectly executed strike. Anirudh's victory was an anomaly, a fluke. It would not happen again.</p>
-</div>
-<div id="page-102" class="page-content-container">
+
     <h2>Chapter 9: The Eye of the Storm</h2>
     <p>Anirudh's next opponent was Vana, a woman whose serene smile was at odds with the palpable aura of power that radiated from her. She was a Sound Bender. The moment the gong sounded, the world tilted on its axis. A low, gut-wrenching hum vibrated in Anirudh's bones, his senses twisting into a knot of confusion. The ground seemed to ripple, the air to thicken. He was fighting blind, deaf, and crippled, lost in a sea of sonic chaos.</p>
     <p>His training at Kanjiram screamed at him to fight back, to push through the noise, to overwhelm it with his own power. But Arjun's voice echoed in his mind: *Find the stillness within.* He stopped fighting. He let the cacophony wash over him, a disorienting, painful wave. And in the heart of the noise, in the deafening silence between the waves of sound, he began to perceive a pattern, a rhythm, a flow. He was no longer fighting the sound; he was listening to its song.</p>
     <p>He began to move with it. He flowed through the gaps in her sonic assault, a ghost in her storm, his movements perfectly in sync with the rhythm of her attack. He was a leaf on her wind. He appeared before her, his hand an inch from her throat, his own form a perfect picture of stillness in the heart of her storm. She had lost. Her eyes widened in shock and disbelief. From the stands, Rohan watched, and for the first time since they had parted ways at the gates of the academy, he felt a flicker of genuine, unsettling unease.</p>
-</div>
-<div id="page-103" class="page-content-container">
+
     <h2>Chapter 10: The Weight of Victory</h2>
     <p>That night, Anirudh did not celebrate his victory. He sat with Meera by a quiet fountain, the sound of the water a soothing balm. "I did not defeat her," he said, his voice thoughtful. "I understood her. Her power was a storm, but every storm has a pattern, a rhythm. I just listened."</p>
     <p>Meera smiled, her eyes reflecting the moonlight. "You are learning, Anirudh. You are learning that power is not just about the strength to break things. It is also about the wisdom to understand them." Anirudh looked at his hands. They were calloused and strong, the hands of a fighter. But for the first time, he felt a different kind of power in them - not the power to destroy, but the power to connect, to feel, to understand. It was a strange, and strangely comforting, feeling.</p>
-</div>
-<div id="page-104" class="page-content-container">
+
     <h2>Chapter 11: The Master's Past</h2>
     <p>Seeing Anirudh's growing understanding, Arjun decided it was time to share a piece of his own past. "I was not always so wise," he admitted one evening, his voice tinged with a long-buried regret. He told them of his youth, of his time as a prodigy at Vidyut Academy, a master of elemental magic with a reckless, arrogant heart. He spoke of a rival, a brilliant alchemist who saw magic not as a weapon, but as a tool for creation.</p>
     <p>"I saw his work as weak, as a waste of true power," Arjun confessed. "We dueled. I unleashed a storm, a maelstrom of power I could barely control, intending to humiliate him. But he did not fight back. He used his alchemy to create a shield, not of force, but of harmony, a field that absorbed and dissipated my storm, leaving me exhausted and foolish in a field of blooming flowers." Arjun shook his head at the memory. "He taught me that the greatest power is not in destruction, but in creation. That man... was your father, Anirudh."</p>
-</div>
-<div id="page-105" class="page-content-container">
+    <p>Anirudh was stunned into silence. He had so many questions, but he couldn't find his voice. He could only stare at Arjun, his mind reeling from the revelation.</p>
+
     <h2>Chapter 12: The Unmovable Mountain</h2>
     <p>Both Anirudh and Rohan reached the quarter-finals. But fate, it seemed, had other plans. Anirudh's opponent was Rudrak, the Thunder Heir, a warrior so powerful he was already a legend in his own time. The fight was not a duel; it was a force of nature. Rudrak's power was absolute, a raw, unstoppable storm of lightning and thunder. Anirudh tried every trick, every technique, every piece of wisdom he had gained. He tried to be the wind, but the hurricane was stronger. He tried to be the stillness, but the thunder shattered the silence.</p>
     <p>It was like trying to redirect a tidal wave with a feather. He was utterly, completely, and humiliatingly outmatched. The fight ended with a single, devastating blow that felt like being struck by a bolt of lightning. It threw Anirudh across the arena like a broken doll, his body and his spirit shattered. He had lost. And in that moment of crushing defeat, he felt like he had lost everything.</p>
-</div>
-<div id="page-106" class="page-content-container">
+
     <h2>Chapter 13: The Anatomy of Failure</h2>
     <p>Anirudh woke in the healing tent, his body a symphony of pain. But the physical agony was nothing compared to the hollow emptiness in his chest. Meera sat beside him, her hands glowing with a soft, silver light as she mended his broken bones. "He was too strong," Anirudh whispered, his voice hoarse. "My new way... it was not enough."</p>
     <p>"Your 'new way' is not a weapon, Anirudh," Meera said softly, her voice a gentle counterpoint to the storm of his self-doubt. "It is a path. And this... this is part of the journey. You cannot understand light without knowing darkness. You cannot know strength without feeling weakness. This pain is not your enemy. It is a teacher." Her words, and the quiet, steady warmth of her healing light, did not erase his failure, but they gave it context. It was not an end. It was a lesson.</p>
-</div>
-<div id="page-107" class="page-content-container">
+
     <h2>Chapter 14: The Hammer and the Key</h2>
     <p>Arjun found him later, staring out at the setting suns, his expression a mask of despair. "You believe power is the ability to overwhelm," Arjun observed, his voice soft. "You faced a greater hammer, and you were shattered. And so now, you believe you are weak."</p>
     <p>Anirudh had no answer. He just stared at the horizon, the memory of his failure a bitter taste in his mouth. "Let me tell you a story of your father," Arjun said. He told Anirudh of a time Raghav had faced a Crimson Earth-shaker, a beast of living stone and molten fury. Raghav did not meet its strength with strength. He had "danced" with it, using his Three Seal Harmony Technique to alter the battlefield, turning the very ground into a flowing river, redirecting the beast's power, soothing its rage, until the great creature, its fury spent, simply collapsed into a deep and peaceful slumber.</p>
     <p>"Rudrak is the greatest hammer in a generation," Arjun concluded, his eyes locking with Anirudh's. "You tried to meet him as a smaller hammer. You were brave, and you were foolish. The lesson, Anirudh, is not 'how do I become a stronger hammer?'. The lesson is... 'how do I become a key?' A key does not need to be strong. It just needs to be the right shape."</p>
 </div>
-<div id="page-108" class="page-content-container">
+<div id="page-108-113-reexpanded" class="page-content-container">
     <h2>Chapter 15: The First Spark</h2>
     <p>The journey back to the wilderness was a quiet one. The sting of defeat was a constant companion. Anirudh's training began anew, but this time, it was different. There were no grand challenges, no dramatic lessons. Arjun had him sit by a stream and watch the water flow over the rocks. He had him feel the grain of the wood in his staff. He had him listen to the silence between the notes of a bird's song.</p>
     <p>"The key is not a thing you make," Arjun explained. "It is a thing you become. It is about understanding the lock. You must learn to see the world not as a collection of objects, but as a web of connections, a flow of energy. You must find the empty spaces, the points of leverage, the hidden pathways." Anirudh began to see the world in a new light, not as a series of obstacles, but as a series of puzzles waiting to be solved.</p>
-</div>
-<div id="page-109" class="page-content-container">
+
     <h2>Chapter 16: The Echo of Power</h2>
     <p>Arjun began to teach Anirudh the basics of the Three Seal Harmony Technique, the style his father had used. It was unlike anything he had ever learned. It was not about generating power, but about guiding it. His first task was to create the simplest seal, the Seal of Stillness. It was a complex pattern of energy that, when formed correctly, would create a small zone of absolute calm.</p>
     <p>For days, Anirudh failed. The energy would not hold its shape, dissipating like smoke. He was trying to force it, to command it, as he had with the leaf. "You are trying to build a dam," Arjun said. "You must become the riverbank. You do not hold the water back. You guide its flow." Anirudh, remembering the mountain's lesson, let go of his effort. He did not try to create the seal. He invited it to form. And in a moment of quiet clarity, the seal appeared, a faint, glowing pattern in the air before him, a perfect, beautiful, and fragile thing.</p>
-</div>
-<div id="page-110" class="page-content-container">
+
     <h2>Chapter 17: The Orphan's Return</h2>
     <p>The lesson was still a fresh, fragile thing in his mind when news came, carried on the wings of a panicked messenger bird. His old village, the one that had scorned him, was under attack by Void-touched beasts. He, Arjun, and Meera rushed back, arriving to a scene of chaos and terror. He returned to a place of ghosts and nightmares, but when he saw Old Lady Elina, the one person who had ever shown him a sliver of kindness, cornered by a monstrous, slavering beast, the fight became brutally personal.</p>
-</div>
-<div id="page-111" class="page-content-container">
+
     <h2>Chapter 18: The Protector's Heart</h2>
     <p>Pushed to his limits, his body still aching from his defeat at the tournament, Anirudh knew he could not win with force. He had to be the key. As the beast lunged, he did not meet it with a blow. He moved to protect. He threw himself in front of Old Lady Elina, his arms spread wide, his body a shield. He was not trying to win. He was not trying to survive. He was only trying to protect.</p>
     <p>In that moment of selfless clarity, something inside him unlocked. A new power, calm, focused, and potent, surged through him. It was not the rage of the storm, but the certainty of the mountain. It was the speed of the wind, guided by the stillness of the stone. It was the Vayu Vajra, the Wind Thunder Form, born not in quiet meditation, but in a moment of selfless, desperate action.</p>
     <p>He moved like a storm, but a storm with a purpose. He struck not with the force of a hammer, but with the precision of a key turning a lock. He dismantled the beast, turning its own strength against it, and saved the village. In the eyes of the villagers, he was no longer an orphan. He was a protector. He had found his path.</p>
-</div>
-<div id="page-112" class="page-content-container">
+
     <h2>Chapter 19: The Weight of a Name</h2>
     <p>That night, by the fire in the now-safe village square, Arjun found Anirudh staring into the flames, his hands trembling slightly. "You are wondering about the power you called upon," Arjun said, not as a question, but as a statement. Anirudh nodded, unable to speak.</p>
     <p>"The Vayu Vajra is not a technique, boy. It is a manifestation," Arjun explained, his voice low. "It is the spirit's answer to a selfless heart. It is the power of the wind, which flows, and the power of the thunder, which strikes. But it is guided by the stillness of the mountain, by a purpose greater than oneself. You did not call it forth to win a fight. You called it forth to protect. That is the key."</p>
     <p>Arjun grew serious, his gaze intense. "But be warned. A power like that, born of such emotion, is a fire that can consume its wielder. It draws upon your life force, your very essence. If you were to use it from a place of rage, or hatred... it would burn you from the inside out, leaving nothing but an empty, echoing shell. You have been given a great gift, Anirudh. Do not let it become your curse."</p>
-</div>
-<div id="page-113" class="page-content-container">
+
     <h2>Chapter 20: The Invitation</h2>
     <p>When he returned to the Whispering Temple, their temporary home in the wilderness, Arjun looked at him with a new light in his eyes. "You have not surpassed my teachings," Anirudh said, a quiet confidence in his voice that was not there before. "I have only just begun to understand them. I have accepted who I am."</p>
     <p>Arjun bowed, not as a master to a student, but as an equal. "Then your training is complete," he said. In that moment of quiet triumph, a messenger bird arrived, its wings beating urgently against the air. It carried a scroll, sealed with the ominous crest of the War Council of Realms. It was an invitation to the grand council, the same council where his father had been betrayed. The final trial was about to begin.</p>
 </div>
 <!-- ACT 6: THE COUNCIL OF SHADOWS -->
-<div id="page-114" class="page-content-container">
+<div id="page-114-121-reexpanded" class="page-content-container">
     <h1>Act 6: The Council of Shadows</h1>
     <h2>Chapter 1: The Road of Whispers</h2>
     <p>The journey to the War Council was a pilgrimage through a world gasping for breath. Anirudh, Arjun, and Meera traveled roads flanked by fallow fields and silent, watchful forests. The air itself seemed heavy with unspoken fear. In the towns, the smiles were brittle, and the nights were guarded by men with haunted eyes. With every league they traveled, Anirudh felt the purpose in his heart sharpen into a fine, hard point. He was no longer just seeking answers; he was seeking justice.</p>
     <p>Beside him, Meera was a bastion of calm. Her quiet strength, the observant stillness in her gaze, became his anchor in the growing storm of his own thoughts. She would often point out small details he would have missed in his focused intensity - a rare flower pushing through a crack in a barren rock, the sound of children's laughter from a hidden courtyard. She was teaching him, in her own quiet way, what they were fighting for.</p>
-</div>
-<div id="page-115" class="page-content-container">
+
     <h2>Chapter 2: The Weight of the Invitation</h2>
     <p>One night, by a meager fire, Anirudh studied the scroll of invitation. The ominous crest of the War Council seemed to mock him. "They invite me to talk," he said, his voice laced with bitterness. "The same council that stood by while my father was murdered."</p>
     <p>Arjun's expression was grim. "This is not an invitation, Anirudh. It is a summons. They are afraid of you, of the power you represent. They want to measure you, to see if you are a tool they can use, or a threat they must eliminate."</p>
     <p>Meera placed a hand on Anirudh's arm. "They may be afraid," she said, her voice firm. "But they are also the only hope for a united front against the growing darkness. We cannot fight this war alone. You must go. Not as your father did, with hope in your heart. But as yourself, with wisdom in your eyes." Anirudh looked at the two of them, his master and his friend, and a new resolve settled in his heart. He would face this council, not as a victim, but as a warrior.</p>
-</div>
-<div id="page-116" class="page-content-container">
+
     <h2>Chapter 3: The Den of Vipers</h2>
     <p>They finally arrived at the War Council of Realms, a fortress not built, but gouged from the heart of a mountain, a place of cold stone and colder politics. The air within the council chamber was a physical weight, thick with centuries of mistrust. Anirudh saw the factions clinging to their own kind: the proud, unbending warriors of the Martial Clans; the aloof, whispering scholars of the Alchemy Order; and the delegates of the Shadow Faction, whose very presence seemed to drain the light from the room.</p>
     <p>He watched a figure, known only as The Whisperer, drift between the delegations like a phantom. Their face was lost in the shadow of a deep cowl, but their influence was a palpable poison. A shared laugh would die, a friendly hand would be withdrawn, a seed of doubt would be planted with a single, honeyed word. Anirudh felt a cold dread creep up his spine. This was not a council of allies; it was a den of vipers, charmed into a dance of self-destruction. This was how his father's dream had died. Not with a bang, but with a whisper.</p>
-</div>
-<div id="page-117" class="page-content-container">
+
     <h2>Chapter 4: A Glimpse of the Past</h2>
     <p>That night, Arjun stood on a secluded balcony, the same one where he had spoken to Anirudh what felt like a lifetime ago. The memories were ghosts, whispering in the wind. He remembered Raghav, standing on this very spot, his face alight with the passion of his dream. He remembered the looks on the faces of the other council members - greed, fear, envy. He remembered the moment of the betrayal, the flash of steel, the look of shocked surprise on his friend's face. The guilt was a cold, heavy stone in his gut. He had failed his friend then. He would not fail his son now.</p>
-</div>
-<div id="page-118" class="page-content-container">
+
     <h2>Chapter 5: The First Ambush</h2>
     <p>The attack came without warning on a lonely mountain pass as they were returning from a scouting mission. One moment, the air was still; the next, it was filled with ghosts. The Shadow Assassins didn't move through the world; they slid between its cracks, their blades not just cutting flesh, but tasting life. The very air grew cold and thin, each breath a struggle.</p>
-</div>
-<div id="page-119" class="page-content-container">
+
     <h2>Chapter 6: The Moon's Shield, The Void's Sword</h2>
     <p>Their leader was Kavrik, a man whose face was a ruin of void-scarred flesh, but whose eyes burned with the cold, dead light of a collapsed star. They ignored Anirudh. Their target was Meera. As they closed in, a vortex of shadow forming around her, a brilliant, blinding nova of silver light erupted from her core. The assassins were hurled back, screeching as the pure, living energy seared their void-touched forms. She was a Moonblood Healer, a living font of life, and the Shadow Faction's natural enemy. Anirudh, stunned for a heartbeat, roared with protective fury and met them head-on.</p>
-</div>
-<div id="page-120" class="page-content-container">
+
     <h2>Chapter 7: The Bitter Taste of Defeat</h2>
     <p>He fought with the grace of a storm, but Kavrik was a void. Anirudh's every strike was swallowed by the man's unnatural defense. He felt his own energy, his own life force, being siphoned away, his movements growing sluggish, his spirit heavy. He faced Kavrik and was utterly, crushingly defeated. As he lay broken on the ground, Kavrik loomed over him, the ghost of a smile on his ruined face. "Your father's blood makes you strong," he hissed, his voice the rustle of dry leaves. "But it is a fire I will enjoy extinguishing. Your entire bloodline will burn first."</p>
-</div>
-<div id="page-121" class="page-content-container">
+
     <h2>Chapter 8: The Price of Light</h2>
     <p>Kavrik and his assassins vanished as quickly as they had appeared, leaving Anirudh broken and Meera exhausted. The burst of light that had saved them had taken a heavy toll on her. She swayed, her face pale, and Arjun caught her before she could fall. Anirudh, his body screaming in protest, dragged himself to her side. He saw the fatigue in her eyes, the way her own light seemed to dim. He had been so focused on his own power, his own legacy, that he had forgotten that she was not just a healer; she was a warrior in her own right, and she was fighting her own battles. He took her hand, his touch a silent promise. He would not let her fight alone.</p>
 </div>
-<div id="page-122" class="page-content-container">
+<div id="page-122-127-reexpanded" class="page-content-container">
     <h2>Chapter 9: The Ruins of Vajradan</h2>
     <p>Arjun carried the wounded and humiliated Anirudh not to a healer, but to the Ruins of Vajradan, a city of shattered towers and sleeping magic, a place where his father had once learned to master the elements. "You fought the void with fire," Arjun said, his voice echoing in the vast, silent halls. "But you cannot burn a vacuum. To defeat the void, you must understand it. And to understand it, you must face the ultimate emptiness: death itself." He led Anirudh to a sealed chamber at the heart of the ruins, a place that hummed with a terrifying, latent power.</p>
-</div>
-<div id="page-123" class="page-content-container">
+
     <h2>Chapter 10: Facing the Void</h2>
-    <p>"This chamber will show you your own end," Arjun explained. "It will strip away everything you are. You must find the spark that remains, or be consumed forever." Inside, Anirudh's world dissolved. He was pulled into a harrowing, vivid vision of his father's last moments. He saw the council chamber, felt the sting of betrayal as Kavrik, his father's sworn brother, stepped aside, allowing the assassins to strike. He heard his father's final, defiant words. He felt his father's life extinguish.</p>
-</div>
-<div id="page-124" class="page-content-container">
+    <p>"This chamber will show you your own end," Arjun explained. "It will strip away everything you are. You must find the spark that remains, or be consumed forever." Inside, Anirudh's world dissolved. He was pulled into a harrowing, vivid vision of his father's last moments. He saw the council chamber, the faces of the men who had betrayed his father, their eyes filled with greed and fear. He felt the sting of betrayal as Kavrik, his father's sworn brother, stepped aside, allowing the assassins to strike. He heard his father's final, defiant words, not of anger, but of sorrow for his lost friend. He felt his father's life extinguish, a light snuffed out in the darkness.</p>
+
     <h2>Chapter 11: The Vayu Vajra Ascendant</h2>
-    <p>Anirudh did not just see it; he lived it. He screamed, not in his mind, but in the chamber, a sound of pure, elemental grief and rage. And from that crucible of loss, a new power was born. He emerged from the chamber not just alive, but reborn in golden fire. The Vayu Vajra Ascendant Form crackled around him, a cloak of lightning and wind, a power so immense it threatened to tear his own body apart even as it obeyed his will. He had touched death, and returned with its power.</p>
-</div>
-<div id="page-125" class="page-content-container">
+    <p>Anirudh did not just see it; he lived it. He screamed, not in his mind, but in the chamber, a sound of pure, elemental grief and rage. And from that crucible of loss, a new power was born. He emerged from the chamber not just alive, but reborn in golden fire. The Vayu Vajra Ascendant Form crackled around him, a cloak of lightning and wind, a power so immense it threatened to tear his own body apart even as it obeyed his will. He had touched death, and returned with its power. His eyes glowed with a golden light, no longer the eyes of a boy, but of a king.</p>
+
     <h2>Chapter 12: The Siege of Kanjiram</h2>
-    <p>They returned to the council to find chaos. The Shadow Faction, emboldened, had thrown their full might at Kanjiram Academy, a brazen declaration of war. A tide of corrupted wild beasts, their eyes glowing with malevolent purple light, crashed against the academy walls. The siege was a maelstrom of chaos and terror.</p>
-</div>
-<div id="page-126" class="page-content-container">
+    <p>They returned to the council to find chaos. The Shadow Faction, emboldened by their victory over Anirudh, had thrown their full might at Kanjiram Academy, a brazen declaration of war. A tide of corrupted wild beasts, their eyes glowing with a malevolent purple light, crashed against the academy walls. The siege was a maelstrom of chaos and terror, the screams of the dying echoing through the air.</p>
+
     <h2>Chapter 13: The Golden Comet</h2>
-    <p>Anirudh, now a warrior transformed, became the eye of the storm. His Ascendant Form was a golden comet on the battlefield, a beacon of impossible hope against the encroaching darkness. He moved with the speed of thought, his every strike a thunderclap, single-handedly turning the tide at the main gate by felling a monstrous Flamehorn Rhino that had shattered the ancient defenses.</p>
-</div>
-<div id="page-127" class="page-content-container">
+    <p>Anirudh, now a warrior transformed, became the eye of the storm. His Ascendant Form was a golden comet on the battlefield, a beacon of impossible hope against the encroaching darkness. He moved with the speed of thought, his every strike a thunderclap that shattered the bodies of the void-touched beasts. He single-handedly turned the tide at the main gate by felling a monstrous Flamehorn Rhino that had shattered the ancient defenses, his staff now a spear of golden light.</p>
+
     <h2>Chapter 14: The Silver Angel</h2>
-    <p>Meera, her heritage now revealed, became a silver angel on the battlefield. She moved through the wounded, her hands glowing, knitting together flesh and bone, her very presence a shield against the creeping shadows of despair. She was not just a healer; she was a symbol of defiance, a testament to the fact that even in the darkest of times, the light of life could not be extinguished.</p>
+    <p>Meera, her heritage now revealed, became a silver angel on the battlefield. She moved through the wounded, her hands glowing with a soft, silver light, knitting together flesh and bone, her very presence a shield against the creeping shadows of despair. She was not just a healer; she was a symbol of defiance, a testament to the fact that even in the darkest of times, the light of life could not be extinguished. She was the anchor that kept the defenders of Kanjiram from falling into despair.</p>
 </div>
-<div id="page-128" class="page-content-container">
+<div id="page-128-133-reexpanded" class="page-content-container">
     <h2>Chapter 15: The Beast King</h2>
     <p>But the enemy had held back their trump card. From the heart of their army, a creature of nightmare emerged: the Obsidian Direwolf, a Beast King of shadow and moonlight, its howl a promise of death. It ignored the chaos, its intelligent, malevolent eyes fixing on the golden comet in the main courtyard. It had found its prey.</p>
-</div>
-<div id="page-129" class="page-content-container">
+
     <h2>Chapter 16: A Duel of Myths</h2>
     <p>The world seemed to hold its breath. The duel was not just a fight; it was a clash of mythic forces. The Direwolf was a living shadow, cloaking itself in darkness to strike from unseen angles, its claws dripping with energy-draining void magic. Anirudh, in his Ascendant Form, was a being of pure, golden light, but he could feel his energy draining, the immense power of the form taking its toll. He was burning out.</p>
-</div>
-<div id="page-130" class="page-content-container">
+
     <h2>Chapter 17: The Alchemist's Legacy</h2>
     <p>Pushed to his absolute limit, his mind raced back to the dusty, forgotten tomes in the library, to the theories of his father. He began to weave intricate, glowing alchemical seals into the air with his free hand, a skill inherited, but never mastered. A seal of Binding to counter the beast's phasing. A seal of Purity to negate its regenerative abilities. The duel shifted from a brawl to a deadly, high-speed chess match. The odds were evened, but Anirudh knew it wasn't enough. He was fading.</p>
-</div>
-<div id="page-131" class="page-content-container">
+
     <h2>Chapter 18: The Final Gamble</h2>
     <p>He made a final, desperate gamble. He drew upon the teachings of the incomplete Death-Resurrection Scroll, a forbidden technique that traded life for absolute power. He channeled his own life force, his very essence, into one, final, cataclysmic strike. "VAYU VAJRA!" he roared, his voice the sound of a star being born. He became a golden meteor, striking the Direwolf with the force of a falling mountain. The beast, and the entire courtyard, were consumed by a blinding, silent explosion of golden light.</p>
-</div>
-<div id="page-132" class="page-content-container">
+
     <h2>Chapter 19: The Silence and the Spark</h2>
     <p>When the light faded, Anirudh lay at the center of a crater, his body still, the golden light of his Ascendant Form extinguished. His heart had stopped. For three long minutes, he was dead. The battle ground to a halt, friend and foe alike staring in stunned silence. And then, Meera reached him. With tears streaming down her face, she poured her own life force, her Moonblood essence, into his still form, a desperate, loving prayer against the encroaching darkness. His heart sputtered, then beat once. Then again. He had won, but at a cost that had nearly shattered them all.</p>
-</div>
-<div id="page-133" class="page-content-container">
+
     <h2>Chapter 20: The Weight of Truth</h2>
-    <p>In the quiet aftermath, amidst the scent of ozone and healing herbs, Arjun sat by Anirudh's bedside and finally unburdened his soul. He told him everything. That his father, Raghav, was not just a great warrior, but the last Alchemist King. He explained that Meera's family were not just villagers, but the sworn guardians of the king's bloodline. And then came the final, devastating blow. Kavrik, the master of the void, the man who had defeated him, the man who had betrayed his father... was once Raghav's most beloved friend, his sworn brother, his most trusted ally. The betrayal was not political; it was personal, a wound that had festered for fifteen years. Anirudh listened, his expression hardening from stone to diamond. The grief, the anger, the loss... it all coalesced into a single point of cold, clear, and absolute resolve. He would not just defeat the Shadow Faction. He would find Kavrik, and he would erase the stain of his betrayal from the world. Word of the impossible victory at Kanjiram spread like wildfire, but it did not bring peace. The Whisperer used the brazen attack to whip the other factions into a frenzy of fear and paranoia. Armies, once held in reserve, began to muster. A final, cataclysmic battle was now inevitable, the stage set in the desolate, cursed landscape of the Valley of Blood Moons.</p>
+    <p>In the quiet aftermath, amidst the scent of ozone and healing herbs, Arjun sat by Anirudh's bedside and finally unburdened his soul. He told him everything. That his father, Raghav, was not just a great warrior, but the last Alchemist King. He explained that Meera's family were not just villagers, but the sworn guardians of the king's bloodline. And then came the final, devastating blow. "Kavrik," Arjun said, his voice heavy with guilt, "the master of the void, the man who defeated you, the man who betrayed your father... he was once Raghav's most beloved friend, his sworn brother, his most trusted ally. They were closer than any two brothers could be."</p>
+    <p>Anirudh listened, his expression hardening from stone to diamond. The grief, the anger, the loss... it all coalesced into a single point of cold, clear, and absolute resolve. "Why?" Anirudh asked, his voice a low, dangerous whisper.</p>
+    <p>"Power," Arjun said simply. "Kavrik believed your father was too soft, too idealistic. He believed that power was meant to be used, to be wielded without restraint. He saw your father's compassion as a weakness. A weakness he sought to correct."</p>
+    <p>The betrayal was not political; it was personal, a wound that had festered for fifteen years. Anirudh would not just defeat the Shadow Faction. He would find Kavrik, and he would erase the stain of his betrayal from the world. Word of the impossible victory at Kanjiram spread like wildfire, but it did not bring peace. The Whisperer used the brazen attack to whip the other factions into a frenzy of fear and paranoia. Armies, once held in reserve, began to muster. A final, cataclysmic battle was now inevitable, the stage set in the desolate, cursed landscape of the Valley of Blood Moons.</p>
 </div>
 <!-- ACT 7: THE VALLEY OF BLOOD MOONS -->
-<div id="page-134" class="page-content-container">
+<div id="page-134-138-reexpanded" class="page-content-container">
     <h1>Act 7: The Valley of Blood Moons</h1>
     <h2>Chapter 1: The Crimson Fields</h2>
     <p>The ground trembled long before the armies clashed. It was a low, guttural vibration that rose through the soles of Anirudh’s boots and settled deep in his bones, a promise of the carnage to come. He stood on a small rise, the banners of the allied armies snapping in the ash-filled wind behind him. Before him, the enemy was a dark, screaming stain on the horizon, a horde of fanatics and twisted, Void-touched beasts. Meera found him there, her silver light a soft, gentle glow against the bloody moonlight. "They are afraid," she said, her voice quiet. "I was talking about our own men." She gestured to a makeshift field hospital, where a young soldier, his face pale, his hand trembling as he clutched a letter, looked up at them. "His name is Kael," Meera said softly. "He has a wife, and a daughter he has never met. He's fighting for them."</p>
     <p>Her words cut through Anirudh's own internal storm. He walked over to the soldier. "Kael," he said, his voice steady. The soldier looked up, startled. "You will see your daughter," Anirudh said, his gaze unwavering. "I promise." The words were not just for the soldier. They were for him. He was not just here to avenge his father. He was here for them. The thought was a sudden, sharp clarity. It did not banish his fear, but it gave it purpose. The horns blew. The world erupted.</p>
-</div>
-<div id="page-135" class="page-content-container">
+
     <h2>Chapter 2: The Tide of Battle</h2>
     <p>The initial impact was a brutal, grinding pulverization of flesh and steel. Anirudh fought in the heart of it, a golden whirlwind of destruction. His first true test was Vorlag the Void-touched, a hulking brute whose skin was like cracked obsidian and whose spear seemed to drink the light. The duel was a dance in a hurricane. Anirudh's staff, a gift from Arjun, turned to black, crumbling rot in his hands as it parried a blow from the void-spear. Disarmed, he was forced into a desperate defense. He slapped his own arms, his chest, his legs, his hands a blur as he traced the glowing alchemical seals of hardening, his skin taking on a golden, metallic sheen. He met the spear not with a weapon, but with his own body. Each blocked blow sent a tremor of black, corrosive energy through him, a pain that was a cold, numbing echo of the void itself. He won, but was left drained and wounded, the victory a stark reminder of the greater battle to come.</p>
-</div>
-<div id="page-136" class="page-content-container">
+
     <h2>Chapter 3: The Ghost on the Cliff</h2>
     <p>High above the battlefield, on a lonely, windswept cliff, Kavrik waited. "He screamed your name at the end, you know," he said as Anirudh arrived, his voice a soft, conversational poison. "Begged me to spare his 'innocent child'. He died believing in innocence. Such a fool." Rage, hot and blinding, surged through Anirudh, but he fought it down, hardening it into a core of pure, cold resolve. "My father died believing in a friend," Anirudh said, his voice dangerously quiet. "He was not the fool in that friendship."</p>
     <p>"Friendship? Hope? Love?" Kavrik laughed, a dry, rasping sound. "They are chains. The attachments of the weak. The Void is pure. It is honest. It offers true strength, free from the sentiment that made your father weak. Join me, Anirudh. You have felt its power. Embrace your true potential."</p>
     <p>"My father believed in people," Anirudh countered, his Vayu Vajra form igniting around him in a swirl of golden energy. "He believed in hope. That is a strength your empty world can never comprehend. I am not him. I am his son. And I will not make his mistake. I will not trust a serpent."</p>
-</div>
-<div id="page-137" class="page-content-container">
+
     <h2>Chapter 4: The Serpent's Kiss</h2>
     <p>The duel was a clash of ideologies made manifest. Kavrik's void style was nihilism, a vortex of life-draining energy. Anirudh's Vayu Vajra was life, a storm of golden light and furious hope. The fight escalated when Kavrik summoned Shadow Doppelgangers, spectral horrors that took the form of Anirudh's parents, their voices whispering his deepest fears. "You let us die," the shade of his mother whispered. "You are not strong enough," the ghost of his father accused. Pushed to the brink, his heart breaking with every parry against the faces of those he loves, Anirudh unleashed the forbidden Death-Resurrection Style, not in anger, but in a desperate, sacrificial burst of life force that annihilated the shadows. The cost was immense, leaving him on the verge of collapse. Kavrik seized the opportunity, plunging the world into an 'Eternal Eclipse'.</p>
-</div>
-<div id="page-138" class="page-content-container">
+
     <h2>Chapter 5: The Light in the Dark</h2>
     <p>In the suffocating, sense-depriving darkness, Anirudh fought on pure instinct, guided by a single thread of silver light he could feel from the battlefield below—Meera. His final strike was a flash of golden lightning that shattered the void and broke Kavrik's blades. Defeated but unrepentant, Kavrik escaped in a mist of shadows, leaving behind a pulsating Void-touched token. "You have won nothing," his voice echoed. "The council room is where your blood will spill."</p>
 </div>
-<div id="page-139" class="page-content-container">
+<div id="page-139-143-reexpanded" class="page-content-container">
     <h2>Chapter 6: The Serpent's Head</h2>
     <p>Anirudh returned to the main battle, exhausted but resolute. He knew Kavrik was just a symptom. The true poison was The Whisperer, and their master, Lord Varash. He found them in the main command tent, surrounded by the elite of the Alchemy Order. The victory celebration was a brief, fragile thing. Lord Varash, his face a mask of grandfatherly pride, raised a toast. "To Anirudh, the hero of Kanjiram!" he boomed, his voice full of false cheer. Then, his expression hardened, and he turned on Anirudh, holding up the Void-touched token Kavrik had left behind. "A hero... or a shadow infiltrator! I found this on the battlefield. Proof of a pact between this boy and the enemy!"</p>
-</div>
-<div id="page-140" class="page-content-container">
+
     <h2>Chapter 7: The Betrayal</h2>
     <p>Before the stunned council could react, assassins from the Alchemy Order, hidden amongst the delegates, struck. The tent erupted into chaos. The General of the Martial Clans was cut down, his honor guard overwhelmed. Arjun, a lion in winter, moved to protect Anirudh, felling the first wave of assassins with a furious grace. But then, a single, poisoned blade, thrown from the back of the tent, found its mark. Arjun gasped, stumbling, a dozen more blades finding him in his moment of weakness. He fell, his last words a desperate, choked plea to Anirudh: "Don't... let the rage... consume you. Be... the key... not... the hammer..."</p>
-</div>
-<div id="page-141" class="page-content-container">
+
     <h2>Chapter 8: The God of Rage</h2>
     <p>Seeing his master fall, something inside Anirudh shattered. The world dissolved into a silent, white-hot scream of pure, untamed, agonizing rage. His body twisted, bones breaking and reforming with sickening cracks, as the raw, elemental power he had struggled to control exploded outward. He was a prisoner in his own mind, a helpless observer as his body became a vessel for something terrible and ancient. *No... no, stop...* he screamed, but his voice was only the roar of the storm. He saw the terror on the faces of his own allies as the Stormbeast, a being of obsidian skin and crackling lightning, a god of pure, agonizing fury, unleashed its indiscriminate wrath.</p>
-</div>
-<div id="page-142" class="page-content-container">
+
     <h2>Chapter 9: The Anchor</h2>
     <p>He felt his consciousness slipping away, drowning in an ocean of rage. But then, a single, soft, silver light pushed through the maelstrom. Meera. She walked into the heart of the storm, her own power a fragile, defiant shield against the raging elements. She did not shout. She did not command. She whispered his name. "Anirudh," she said, her voice a lifeline, a thread of memory and hope in the hurricane of his rage. "I'm here. Come back. Remember your promise. Remember Kael." The beast roared, lashing out, but the man inside, hearing her voice, began to fight back.</p>
-</div>
-<div id="page-143" class="page-content-container">
+
     <h2>Chapter 10: The Alchemist's End</h2>
     <p>The final confrontation with Varash was a battle for Anirudh's soul. "You cannot control it, boy!" Varash screamed, his own form crackling with the borrowed power of the Crimson Philosopher's Stone he held in his hand. "But I can teach you! Together, we can be gods! We will cleanse this world with fire and build a new one, an orderly one, from the ashes!" The temptation of control, of purpose for his pain, was a siren's call. But in the storm of his mind, Anirudh saw the faces of those he loved: his mother's sacrifice, Arjun's final plea, Meera's unwavering faith. He chose to be a man.</p>
     <p>With a serene, impossible clarity, he did not fight the storm within him. He guided it. He wove his father's Three Seal Harmony Technique, a style of balance and control, with the raw, chaotic power of the Stormbeast. He was not just using two styles; he had created a new one, a perfect synthesis of wisdom and power, of rage and purpose. He became a living conduit of focused, controlled energy. He did not strike Varash. He struck the Crimson Philosopher's Stone. The stone, unable to contain the raw, purified power of a living storm, overloaded. With a deafening, silent explosion, Varash and his ambition were obliterated, erased from existence.</p>
 </div>
-<div id="page-144" class="page-content-container">
+<div id="page-144-153-reexpanded" class="page-content-container">
     <h2>Chapter 11: The Cost of Victory</h2>
     <p>As Varash turned to dust, the power of the Crimson Philosopher's Stone, now unstable, lashed out. A wave of raw, chaotic energy erupted from the fading light, striking the wounded Arjun. Meera screamed, rushing to his side, her own light battling the corrosive energy that threatened to consume him. Anirudh, his own power spent, could only watch in horror as the two people he loved most fought for their lives.</p>
-</div>
-<div id="page-145" class="page-content-container">
+
     <h2>Chapter 12: The Long Road to Dawn</h2>
-    <p>The weeks that followed were a blur of pain and healing. The war was over, but the victory felt hollow. Arjun was alive, but crippled, the void-poison a permanent, chilling echo in his limbs. Meera had exhausted her own life force to save him, and her light was now a faint, flickering candle. The world was saved, but his small world was shattered.</p>
-</div>
-<div id="page-146" class="page-content-container">
+    <p>The weeks that followed were a blur of pain and healing. The war was over, but the victory felt hollow. Arjun was alive, but crippled, the void-poison a permanent, chilling echo in his limbs. He would never fight again. Meera had exhausted her own life force to save him, and her light was now a faint, flickering candle. The world was saved, but his small world was shattered.</p>
+
     <h2>Chapter 13: The New Council</h2>
-    <p>From the ashes of the old, a new council was formed. The delegates, humbled and weary, looked to Anirudh not with suspicion, but with a new, fragile hope. They offered him a seat at the council, a position of power. He refused. "My place is not in a council room," he said, his voice quiet but firm. "It is out there, with the people, helping to rebuild what was broken."</p>
-</div>
-<div id="page-147" class="page-content-container">
+    <p>From the ashes of the old, a new council was formed. The delegates, humbled and weary, looked to Anirudh not with suspicion, but with a new, fragile hope. They offered him a seat at the council, a position of power. He refused. "My place is not in a council room," he said, his voice quiet but firm. "It is out there, with the people, helping to rebuild what was broken. That is the lesson my father taught me. That is the lesson I will honor."</p>
+
     <h2>Chapter 14: A Brother's Return</h2>
-    <p>Rohan, who had fought bravely in the final battle, approached Anirudh. The arrogance was gone, replaced by a quiet respect. "I was wrong about you," he admitted, his voice stiff with the unfamiliar taste of humility. "I saw a hammer, and I thought you were a nail. But you were the forge all along." He offered his sword, and his loyalty, to Anirudh. The rivalry was over, replaced by a bond forged in the fires of war.</p>
-</div>
-<div id="page-148" class="page-content-container">
+    <p>Rohan, who had fought bravely in the final battle, approached Anirudh. The arrogance was gone, replaced by a quiet respect. "I was wrong about you," he admitted, his voice stiff with the unfamiliar taste of humility. "I saw a hammer, and I thought you were a nail. But you were the forge all along." He offered his sword, and his loyalty, to Anirudh. "Let me help you rebuild," he said. "Let me help you protect what we have saved." The rivalry was over, replaced by a bond forged in the fires of war.</p>
+
     <h2>Chapter 15: The Weight of a Sword</h2>
-    <p>In the quiet of the healing chambers, Arjun pressed his own sword into Anirudh's hands. It was a simple, elegant blade, but it felt heavier than a mountain. "The master's journey is over," Arjun said, his voice weak but steady. "The hero's has just begun. Do not try to be perfect, Anirudh. Just try to be good."</p>
-</div>
-<div id="page-149" class="page-content-container">
+    <p>In the quiet of the healing chambers, Arjun pressed his own sword into Anirudh's hands. It was a simple, elegant blade, but it felt heavier than a mountain. "My fighting days are over, my boy," Arjun said, his voice weak but steady. "But yours are just beginning. Take this. It will serve you well. Do not try to be perfect, Anirudh. Just try to be good."</p>
+
     <h2>Chapter 16: A Father's Grave</h2>
     <p>Under a peaceful moon, Anirudh and Meera stood before a simple, unmarked stone they had erected for his father. "I'm sorry it took me so long," Anirudh whispered to the stone, his hand resting on its cool surface. "I understand now. Power isn't a weapon. It's a shield. It isn't what I inherited that matters. It's what I choose to protect. I will try... to be a man worthy of your memory."</p>
-</div>
-<div id="page-150" class="page-content-container">
+
     <h2>Chapter 17: A Quiet Promise</h2>
     <p>Meera took his hand, her fingers lacing with his. Her light was still faint, but it was steady, and it was warm. "You are not alone, Anirudh," she said, her voice a quiet promise. "You never were." He looked at her, at the unwavering faith in her eyes, and he felt a sense of peace he had never known before. The rage was gone, the grief was quiet. All that was left was a shared hope for the future.</p>
-</div>
-<div id="page-151" class="page-content-container">
+
     <h2>Chapter 18: The Seeds of a New Age</h2>
-    <p>In the months that followed, Anirudh, Meera, and Rohan traveled the land, not as warriors, but as builders. They helped to replant the fallow fields, to rebuild the shattered villages, to mend the broken hearts of a world scarred by war. Anirudh used his father's alchemical knowledge not to create weapons, but to purify the land, to bring life back to the places the void had touched.</p>
-</div>
-<div id="page-152" class="page-content-container">
+    <p>In the months that followed, Anirudh, Meera, and Rohan traveled the land, not as warriors, but as builders. They helped to replant the fallow fields, to rebuild the shattered villages, to mend the broken hearts of a world scarred by war. Anirudh used his father's alchemical knowledge not to create weapons, but to purify the land, to bring life back to the places the void had touched. He was no longer a warrior. He was a healer. A king in all but name.</p>
+
     <h2>Chapter 19: The Whispering Mountain</h2>
     <p>But the world was not entirely at peace. On a distant mountain range, a colossal shadow shifted. A slumbering titan, its form so vast it was mistaken for the mountain itself, had been awakened by the echoes of their battle. It turned its ancient, stony head towards the lands of men, its eyes, two points of cold, ancient light, blinking open for the first time in millennia.</p>
-</div>
-<div id="page-153" class="page-content-container">
+
     <h2>Chapter 20: The Age of Monsters</h2>
     <p>The war was over. The age of monsters was just beginning. Anirudh, standing on a hill overlooking a peaceful, rebuilding valley, felt the tremor in the earth. He looked to the horizon, his eyes narrowed, his hand instinctively going to the hilt of Arjun's sword. He was not afraid. He was ready. The hero's journey was far from over. It was just beginning.</p>
 </div>


### PR DESCRIPTION
In line with your request for a more in-depth story, I've expanded the narrative in `index.html` by adding more content, dialogue, and descriptive detail to each act. I also introduced new characters and subplots to enrich the story.

The changes include:
- Rewriting and expanding all 7 acts of the story.
- Introducing new characters like Elina and Master Vayu.
- Fleshing out character arcs and relationships.
- Adding more emotional depth and detail to key scenes.
- Restructuring the HTML to combine smaller page sections into larger, more cohesive narrative blocks.
- Updating the `blueprint.md` to reflect the new plan and changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated project title to “Child of the Crimson Pendant - Story Enhancement.”
  - Replaced outdated website structure with a current-state overview focused on enhancing the story.
  - Introduced an iterative, act-by-act editing plan with review checkpoints.
  - Added steps: restore Act 1, re-expand with richer detail and a new character, gather feedback, expand Acts 2–7, and final review.
  - Refocused scope on narrative depth within the main page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->